### PR TITLE
feat: 회원탈퇴, 토큰재발급 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,13 +50,13 @@ dependencies {
     implementation 'org.springframework.data:spring-data-redis'
     implementation 'org.springframework.data:spring-data-redis'
     implementation 'org.apache.commons:commons-pool2'
-    testImplementation  'org.testcontainers:testcontainers:1.19.0'
+    testImplementation 'org.testcontainers:testcontainers:1.19.0'
     testImplementation "org.testcontainers:junit-jupiter:1.19.0"
 
     // jwt
-    compileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
-    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
-    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
     // QueryDSL
     implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'

--- a/src/main/java/org/example/oddventure/common/aop/UserValidationAspect.java
+++ b/src/main/java/org/example/oddventure/common/aop/UserValidationAspect.java
@@ -1,0 +1,28 @@
+package org.example.oddventure.common.aop;
+
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.example.oddventure.domain.auth.dto.AuthUser;
+import org.example.oddventure.domain.auth.exception.AuthErrorCode;
+import org.example.oddventure.domain.auth.exception.AuthException;
+import org.example.oddventure.domain.user.repository.UserRepository;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class UserValidationAspect {
+
+    private final UserRepository userRepository;
+
+    @Before("@annotation(ValidUser)")
+    public void validateUser() {
+        AuthUser authUser = (AuthUser) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+
+        userRepository.findById(authUser.id())
+                .filter(u -> u.getUserRole() == authUser.userRole())
+                .orElseThrow(() -> new AuthException(AuthErrorCode.ACCESS_TOKEN_MISMATCH));
+    }
+}

--- a/src/main/java/org/example/oddventure/common/aop/ValidUser.java
+++ b/src/main/java/org/example/oddventure/common/aop/ValidUser.java
@@ -1,0 +1,11 @@
+package org.example.oddventure.common.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidUser {
+}

--- a/src/main/java/org/example/oddventure/common/entity/BaseEntity.java
+++ b/src/main/java/org/example/oddventure/common/entity/BaseEntity.java
@@ -3,12 +3,11 @@ package org.example.oddventure.common.entity;
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
-import java.time.LocalDateTime;
 
 @Getter
 @MappedSuperclass
@@ -23,4 +22,14 @@ public abstract class BaseEntity {
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
 
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    @Column(name = "is_deleted", nullable = false)
+    private boolean deleted;
+
+    public void delete() {
+        this.deleted = true;
+        this.deletedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/org/example/oddventure/domain/auth/controller/AuthController.java
+++ b/src/main/java/org/example/oddventure/domain/auth/controller/AuthController.java
@@ -1,20 +1,26 @@
 package org.example.oddventure.domain.auth.controller;
 
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
+import java.time.Duration;
 import lombok.RequiredArgsConstructor;
+import org.example.oddventure.common.aop.ValidUser;
 import org.example.oddventure.common.dto.response.ApiResponse;
 import org.example.oddventure.domain.auth.dto.AuthUser;
 import org.example.oddventure.domain.auth.dto.request.LoginRequest;
 import org.example.oddventure.domain.auth.dto.request.SignupRequest;
 import org.example.oddventure.domain.auth.dto.request.WithdrawRequest;
+import org.example.oddventure.domain.auth.dto.response.AccessTokenResponse;
 import org.example.oddventure.domain.auth.dto.response.LoginResponse;
 import org.example.oddventure.domain.auth.dto.response.SignupResponse;
 import org.example.oddventure.domain.auth.service.AuthService;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -35,26 +41,58 @@ public class AuthController {
 
     @PostMapping("/login")
     public ResponseEntity<ApiResponse<LoginResponse>> login(
-            @Valid @RequestBody LoginRequest request
+            @Valid @RequestBody LoginRequest request,
+            HttpServletResponse httpResponse
     ) {
         LoginResponse response = authService.login(request);
+
+        ResponseCookie refreshCookie = ResponseCookie.from("refreshToken", response.refreshToken())
+                .httpOnly(true)
+                .secure(true)
+                .path("/")
+                .maxAge(Duration.ofDays(7))
+                .sameSite("Strict")
+                .build();
+
+        httpResponse.addHeader("Set-Cookie", refreshCookie.toString());
+
         return ApiResponse.success(response, "로그인 되었습니다.");
     }
 
     @PostMapping("/logout")
-    public ResponseEntity<ApiResponse<Object>> logout(
-            @AuthenticationPrincipal AuthUser user
+    public ResponseEntity<ApiResponse<String>> logout(
+            @AuthenticationPrincipal AuthUser user,
+            HttpServletResponse httpResponse
     ) {
         authService.logout(user.id());
+
+        ResponseCookie deleteCookie = ResponseCookie.from("refreshToken", "")
+                .httpOnly(true)
+                .secure(true)
+                .path("/")
+                .maxAge(0)
+                .build();
+
+        httpResponse.addHeader("Set-Cookie", deleteCookie.toString());
+
         return ApiResponse.success(null, "로그아웃 되었습니다.");
     }
 
-    @PostMapping("/withdraw")
-    public ResponseEntity<ApiResponse<Object>> withdraw(
-            @RequestHeader("Authorization") String token,
-            @RequestBody WithdrawRequest withdrawRequest
+    @ValidUser
+    @DeleteMapping("/withdraw")
+    public ResponseEntity<ApiResponse<String>> withdraw(
+            @AuthenticationPrincipal AuthUser user,
+            @Valid @RequestBody WithdrawRequest request
     ) {
+        authService.withdraw(user.id(), request);
+        return ApiResponse.success(null, "회원탈퇴 되었습니다.");
+    }
 
-        return null;
+    @PostMapping("/refresh")
+    public ResponseEntity<ApiResponse<AccessTokenResponse>> refresh(
+            @CookieValue(value = "refreshToken", required = false) String refreshToken
+    ) {
+        AccessTokenResponse newAccessToken = authService.refresh(refreshToken);
+        return ApiResponse.success(newAccessToken, "토큰이 재발급되었습니다.");
     }
 }

--- a/src/main/java/org/example/oddventure/domain/auth/dto/request/WithdrawRequest.java
+++ b/src/main/java/org/example/oddventure/domain/auth/dto/request/WithdrawRequest.java
@@ -1,6 +1,10 @@
 package org.example.oddventure.domain.auth.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
+
 public record WithdrawRequest(
+
+        @NotBlank(message = "비밀번호는 필수입니다.")
         String password
 ) {
 }

--- a/src/main/java/org/example/oddventure/domain/auth/dto/response/AccessTokenResponse.java
+++ b/src/main/java/org/example/oddventure/domain/auth/dto/response/AccessTokenResponse.java
@@ -1,0 +1,6 @@
+package org.example.oddventure.domain.auth.dto.response;
+
+public record AccessTokenResponse(
+        String accessToken
+) {
+}

--- a/src/main/java/org/example/oddventure/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/org/example/oddventure/domain/auth/exception/AuthErrorCode.java
@@ -10,12 +10,15 @@ import org.springframework.http.HttpStatus;
 public enum AuthErrorCode implements ErrorCode {
 
     // 토큰 관련
-    JWT_INVALID_SIGNATURE(HttpStatus.UNAUTHORIZED, "유효하지 않은 JWT 서명입니다."),
-    JWT_EXPIRED(HttpStatus.UNAUTHORIZED, "만료된 JWT 토큰입니다."),
-    JWT_UNSUPPORTED(HttpStatus.BAD_REQUEST, "지원되지 않는 JWT 토큰입니다."),
-    JWT_INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다."),
-    JWT_CANNOT_FIND_TOKEN(HttpStatus.NOT_FOUND, "JWT 토큰을 찾을 수 없습니다."),
+    TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "유효하지 않은 JWT 토큰입니다."),
+    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "만료된 JWT 토큰입니다."),
+    TOKEN_UNSUPPORTED(HttpStatus.BAD_REQUEST, "지원되지 않는 JWT 형식입니다."),
+    TOKEN_INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "JWT 처리 중 서버 오류가 발생했습니다."),
+    TOKEN_NOT_FOUND(HttpStatus.BAD_REQUEST, "JWT 토큰을 찾을 수 없습니다."),
+    ACCESS_TOKEN_MISMATCH(HttpStatus.FORBIDDEN, "액세스 토큰이 사용자 정보와 일치하지 않습니다."),
+    REFRESH_TOKEN_MISMATCH(HttpStatus.FORBIDDEN, "리프레시 토큰이 일치하지 않습니다."),
 
+    // 사용자 인증 관련
     INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "이메일 또는 비밀번호가 올바르지 않습니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/org/example/oddventure/domain/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/org/example/oddventure/domain/auth/jwt/JwtAuthenticationFilter.java
@@ -10,11 +10,10 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.example.oddventure.common.dto.response.ApiErrorResponse;
 import org.example.oddventure.domain.auth.dto.AuthUser;
 import org.example.oddventure.domain.auth.exception.AuthErrorCode;
 import org.example.oddventure.domain.user.enums.UserRole;
@@ -57,19 +56,19 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 }
             } catch (SecurityException | MalformedJwtException e) {
                 log.error("Invalid JWT signature", e);
-                sendErrorResponse(httpResponse, AuthErrorCode.JWT_INVALID_SIGNATURE);
+                sendErrorResponse(httpRequest, httpResponse, AuthErrorCode.TOKEN_INVALID);
                 return;
             } catch (ExpiredJwtException e) {
                 log.error("Expired JWT token", e);
-                sendErrorResponse(httpResponse, AuthErrorCode.JWT_EXPIRED);
+                sendErrorResponse(httpRequest, httpResponse, AuthErrorCode.TOKEN_EXPIRED);
                 return;
             } catch (UnsupportedJwtException e) {
                 log.error("Unsupported JWT token", e);
-                sendErrorResponse(httpResponse, AuthErrorCode.JWT_UNSUPPORTED);
+                sendErrorResponse(httpRequest, httpResponse, AuthErrorCode.TOKEN_UNSUPPORTED);
                 return;
             } catch (Exception e) {
                 log.error("Internal server error", e);
-                sendErrorResponse(httpResponse, AuthErrorCode.JWT_INTERNAL_ERROR);
+                sendErrorResponse(httpRequest, httpResponse, AuthErrorCode.TOKEN_INTERNAL_ERROR);
                 return;
             }
         }
@@ -93,18 +92,17 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     /**
      * HTTP 에러 응답을 JSON 형태로 클라이언트에게 전송하는 메서드
      *
+     * @param httpRequest  클라이언트의 요청
      * @param httpResponse 클라이언트에게 보낼 응답
-     * @param errorCode    AuthErrorCode(상태 코드 및 에러 메시지 포함)
+     * @param errorCode    인증 오류 코드(상태 코드 및 에러 메시지 포함)
      * @throws IOException 응답 작성 중 IO 오류 발생 시
      */
-    private void sendErrorResponse(HttpServletResponse httpResponse, AuthErrorCode errorCode)
+    private void sendErrorResponse(HttpServletRequest httpRequest, HttpServletResponse httpResponse,
+                                   AuthErrorCode errorCode)
             throws IOException {
+        ApiErrorResponse errorResponse = ApiErrorResponse.from(errorCode, httpRequest);
         httpResponse.setStatus(errorCode.getHttpStatus().value());
         httpResponse.setContentType("application/json;charset=UTF-8");
-        Map<String, Object> errorResponse = new HashMap<>();
-        errorResponse.put("status", errorCode.getHttpStatus().name());
-        errorResponse.put("code", errorCode.getHttpStatus().value());
-        errorResponse.put("message", errorCode.getMessage());
         httpResponse.getWriter().write(objectMapper.writeValueAsString(errorResponse));
     }
 }

--- a/src/main/java/org/example/oddventure/domain/auth/jwt/JwtConstants.java
+++ b/src/main/java/org/example/oddventure/domain/auth/jwt/JwtConstants.java
@@ -6,4 +6,5 @@ public class JwtConstants {
     public static final long ACCESS_TOKEN_EXPIRATION = 60 * 60 * 1000L; // 60분
     public static final long REFRESH_TOKEN_EXPIRATION = 7 * 24 * 60 * 60 * 1000L; // 7일
     public static final String REFRESH_TOKEN_PREFIX = "refresh_token:";
+    public static final String CLAIM_USER_ROLE = "userRole";
 }

--- a/src/main/java/org/example/oddventure/domain/auth/jwt/JwtUtil.java
+++ b/src/main/java/org/example/oddventure/domain/auth/jwt/JwtUtil.java
@@ -2,9 +2,11 @@ package org.example.oddventure.domain.auth.jwt;
 
 import static org.example.oddventure.domain.auth.jwt.JwtConstants.ACCESS_TOKEN_EXPIRATION;
 import static org.example.oddventure.domain.auth.jwt.JwtConstants.BEARER_PREFIX;
+import static org.example.oddventure.domain.auth.jwt.JwtConstants.CLAIM_USER_ROLE;
 import static org.example.oddventure.domain.auth.jwt.JwtConstants.REFRESH_TOKEN_EXPIRATION;
 
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
@@ -52,7 +54,7 @@ public class JwtUtil {
 
         return Jwts.builder()
                 .setSubject(String.valueOf(userId))
-                .claim("userRole", userRole)
+                .claim(CLAIM_USER_ROLE, userRole)
                 .setExpiration(new Date(date.getTime() + ACCESS_TOKEN_EXPIRATION))
                 .setIssuedAt(date)
                 .signWith(key, signatureAlgorithm)
@@ -86,9 +88,8 @@ public class JwtUtil {
         if (StringUtils.hasText(tokenValue) && tokenValue.startsWith(BEARER_PREFIX)) {
             return tokenValue.substring(7);
         }
-        throw new AuthException(AuthErrorCode.JWT_CANNOT_FIND_TOKEN);
+        throw new AuthException(AuthErrorCode.TOKEN_NOT_FOUND);
     }
-
 
     /**
      * payload 부분만 추출하는 메서드
@@ -102,5 +103,44 @@ public class JwtUtil {
                 .build()
                 .parseClaimsJws(token)
                 .getBody();
+    }
+
+    /**
+     * JWT 토큰 유효성 검증 메서드
+     *
+     * @param token 클라이언트가 전달한 JWT 문자열
+     * @return 유효한 토큰이면 true, 그렇지 않으면 false
+     */
+    public boolean validateToken(String token) {
+
+        try {
+            Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    /**
+     * JWT 토큰에서 사용자 ID를 추출하는 메서드
+     *
+     * @param token JWT 문자열
+     * @return 토큰의 subject에 저장된 사용자 ID
+     */
+    public Long extractUserId(String token) {
+        return Long.parseLong(extractClaims(token).getSubject());
+    }
+
+    /**
+     * JWT 토큰에서 사용자 권한을 추출하는 메서드
+     *
+     * @param token JWT 문자열
+     * @return 토큰의 userRole 클레임에 저장된 사용자 권한
+     */
+    public UserRole extractUserRole(String token) {
+        return UserRole.valueOf(extractClaims(token).get(CLAIM_USER_ROLE, String.class));
     }
 }

--- a/src/main/java/org/example/oddventure/domain/auth/service/AuthService.java
+++ b/src/main/java/org/example/oddventure/domain/auth/service/AuthService.java
@@ -4,9 +4,11 @@ import static org.example.oddventure.domain.auth.jwt.JwtConstants.REFRESH_TOKEN_
 
 import java.time.Duration;
 import lombok.RequiredArgsConstructor;
+import org.example.oddventure.domain.admin.exception.AdminErrorCode;
 import org.example.oddventure.domain.auth.dto.request.LoginRequest;
 import org.example.oddventure.domain.auth.dto.request.SignupRequest;
 import org.example.oddventure.domain.auth.dto.request.WithdrawRequest;
+import org.example.oddventure.domain.auth.dto.response.AccessTokenResponse;
 import org.example.oddventure.domain.auth.dto.response.LoginResponse;
 import org.example.oddventure.domain.auth.dto.response.SignupResponse;
 import org.example.oddventure.domain.auth.exception.AuthErrorCode;
@@ -93,10 +95,42 @@ public class AuthService {
     /**
      * 회원 탈퇴
      *
-     * @param token   Access Token
+     * @param userId  로그인한 사용자의 고유 ID
      * @param request 회원 탈퇴 요청 정보 (비밀번호 확인)
      */
-    public void withdraw(String token, WithdrawRequest request) {
+    @Transactional
+    public void withdraw(Long userId, WithdrawRequest request) {
 
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new InvalidUserException(AdminErrorCode.USER_NOT_FOUND));
+
+        if (!passwordEncoder.matches(request.password(), user.getPassword())) {
+            throw new InvalidUserException(UserErrorCode.USR_PASSWORD_INCORRECT);
+        }
+
+        if (user.isDeleted()) {
+            throw new InvalidUserException(UserErrorCode.USR_ALREADY_WITHDRAWN);
+        }
+
+        user.delete();
+        redisTemplate.delete(REFRESH_TOKEN_PREFIX + userId);
+    }
+
+    public AccessTokenResponse refresh(String refreshToken) {
+
+        if (refreshToken == null || !jwtUtil.validateToken(refreshToken)) {
+            throw new AuthException(AuthErrorCode.TOKEN_INVALID);
+        }
+
+        Long userId = jwtUtil.extractUserId(refreshToken);
+        String storedToken = redisTemplate.opsForValue().get(REFRESH_TOKEN_PREFIX + userId);
+
+        if (storedToken == null || !storedToken.equals(refreshToken)) {
+            throw new AuthException(AuthErrorCode.REFRESH_TOKEN_MISMATCH);
+        }
+
+        String newAccessToken = jwtUtil.createAccessToken(userId, jwtUtil.extractUserRole(refreshToken));
+
+        return new AccessTokenResponse(newAccessToken);
     }
 }

--- a/src/main/java/org/example/oddventure/domain/bet/entity/Bet.java
+++ b/src/main/java/org/example/oddventure/domain/bet/entity/Bet.java
@@ -11,7 +11,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import java.math.BigDecimal;
-import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -51,12 +50,6 @@ public class Bet extends BaseEntity {
     @Column(name = "is_win", nullable = false)
     private boolean isWin;
 
-    @Column(name = "is_deleted", nullable = false)
-    private boolean isDeleted = false;
-
-    @Column(name = "deleted_at", nullable = false)
-    private LocalDateTime deletedAt;
-
     @Builder
     public Bet(User user, Match match, SelectedTeam selectedTeam, BigDecimal betAmount, BigDecimal oddsAtBetting,
                boolean isWin) {
@@ -66,10 +59,5 @@ public class Bet extends BaseEntity {
         this.betAmount = betAmount;
         this.oddsAtBetting = oddsAtBetting;
         this.isWin = isWin;
-    }
-
-    public void delete(boolean isDeleted) {
-        this.isDeleted = isDeleted;
-        this.deletedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/org/example/oddventure/domain/bet/service/BetService.java
+++ b/src/main/java/org/example/oddventure/domain/bet/service/BetService.java
@@ -89,7 +89,7 @@ public class BetService {
                 .orElseThrow(() -> new MatchException(MatchErrorCode.MATCH_NOT_FOUND));
         validateCancelable(match.getStatus());
 
-        bet.delete(true);
+        bet.delete();
 
         // 환불
         User user = bet.getUser();

--- a/src/main/java/org/example/oddventure/domain/user/entity/User.java
+++ b/src/main/java/org/example/oddventure/domain/user/entity/User.java
@@ -41,9 +41,6 @@ public class User extends BaseEntity {
     @Column(nullable = false)
     private BigDecimal point;
 
-    @Column(name = "is_deleted", nullable = false)
-    private boolean isDeleted = false;
-
     @Builder
     public User(String username, String email, String password, UserRole userRole) {
         this.username = username;

--- a/src/main/java/org/example/oddventure/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/org/example/oddventure/domain/user/exception/UserErrorCode.java
@@ -11,6 +11,7 @@ public enum UserErrorCode implements ErrorCode {
     USR_INVALID_USER_ID(HttpStatus.BAD_REQUEST, "유효하지 않은 유저 ID 입니다."),
     USR_INVALID_USER_ROLE(HttpStatus.BAD_REQUEST, "유효하지 않은 유저 권한"),
     USR_PASSWORD_INCORRECT(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
+    USR_ALREADY_WITHDRAWN(HttpStatus.BAD_REQUEST, "이미 탈퇴한 회원입니다."),
 
     ALREADY_EXIST_EMAIL(HttpStatus.CONFLICT, "이미 존재하는 이메일 입니다.");
 

--- a/src/test/java/org/example/oddventure/domain/auth/jwt/JwtUtilTest.java
+++ b/src/test/java/org/example/oddventure/domain/auth/jwt/JwtUtilTest.java
@@ -1,0 +1,81 @@
+package org.example.oddventure.domain.auth.jwt;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Base64;
+import org.example.oddventure.domain.user.enums.UserRole;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class JwtUtilTest {
+
+    private JwtUtil jwtUtil;
+
+    @BeforeEach
+    void setUp() {
+        jwtUtil = new JwtUtil();
+        String secretKey = Base64.getEncoder().encodeToString("secretkeyabcdefghijklmnopqrstuvwxyz".getBytes());
+        ReflectionTestUtils.setField(jwtUtil, "secretKey", secretKey);
+        jwtUtil.init();
+    }
+
+    @Test
+    @DisplayName("액세스 토큰 생성 성공")
+    void createAccessToken_success() {
+
+        // given
+        Long userId = 1L;
+        UserRole role = UserRole.ROLE_USER;
+
+        // when
+        String token = jwtUtil.createAccessToken(userId, role);
+
+        // then
+        assertEquals(role, jwtUtil.extractUserRole(token));
+    }
+
+    @Test
+    @DisplayName("리프레시 토큰 생성 및 검증 성공")
+    void createRefreshToken_success() {
+
+        // given
+        Long userId = 2L;
+
+        // when
+        String token = jwtUtil.createRefreshToken(userId);
+        boolean isValid = jwtUtil.validateToken(token);
+
+        // then
+        assertTrue(isValid);
+        assertEquals(userId, jwtUtil.extractUserId(token));
+    }
+
+    @Test
+    @DisplayName("Bearer 접두사 제거 성공")
+    void substringToken_success() {
+
+        // given
+        String bearerToken = "Bearer abc.def.ghi";
+
+        // when
+        String result = jwtUtil.substringToken(bearerToken);
+
+        // then
+        assertEquals("abc.def.ghi", result);
+    }
+
+    @Test
+    @DisplayName("토큰 유효성 검증 실패")
+    void validateToken_fail() {
+
+        // given
+        String invalidToken = "invalid.token.value";
+
+        // when & then
+        assertFalse(jwtUtil.validateToken(invalidToken));
+    }
+}

--- a/src/test/java/org/example/oddventure/domain/auth/unit/AuthControllerTest.java
+++ b/src/test/java/org/example/oddventure/domain/auth/unit/AuthControllerTest.java
@@ -3,11 +3,13 @@ package org.example.oddventure.domain.auth.unit;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.Cookie;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import org.example.oddventure.domain.auth.config.SecurityConfig;
@@ -15,6 +17,8 @@ import org.example.oddventure.domain.auth.controller.AuthController;
 import org.example.oddventure.domain.auth.dto.AuthUser;
 import org.example.oddventure.domain.auth.dto.request.LoginRequest;
 import org.example.oddventure.domain.auth.dto.request.SignupRequest;
+import org.example.oddventure.domain.auth.dto.request.WithdrawRequest;
+import org.example.oddventure.domain.auth.dto.response.AccessTokenResponse;
 import org.example.oddventure.domain.auth.dto.response.LoginResponse;
 import org.example.oddventure.domain.auth.dto.response.SignupResponse;
 import org.example.oddventure.domain.auth.jwt.JwtUtil;
@@ -113,7 +117,7 @@ public class AuthControllerTest {
     }
 
     @Test
-    @WithMockUser(roles = {"USER"})
+    @WithMockUser(roles = "USER")
     @DisplayName("POST /logout - 로그아웃 성공")
     void logout() throws Exception {
 
@@ -127,6 +131,49 @@ public class AuthControllerTest {
                                 new UsernamePasswordAuthenticationToken(authUser, null, authUser.getAuthorities()))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.message").value("로그아웃 되었습니다."))
+                .andExpect(jsonPath("$.success").value(true));
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    @DisplayName("DELETE /withdraw - 회원 탈퇴 성공")
+    void withdraw_success() throws Exception {
+
+        // given
+        AuthUser authUser = new AuthUser(1L, UserRole.ROLE_USER);
+        WithdrawRequest request = new WithdrawRequest("hello123!@#");
+
+        doNothing().when(authService).withdraw(authUser.id(), request);
+
+        // when & then
+        mockMvc.perform(delete("/api/v1/auth/withdraw")
+                        .with(authentication(
+                                new UsernamePasswordAuthenticationToken(authUser, null, authUser.getAuthorities())))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("회원탈퇴 되었습니다."))
+                .andExpect(jsonPath("$.success").value(true));
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    @DisplayName("POST /refresh - 토큰 재발급 성공")
+    void refresh_success() throws Exception {
+
+        // given
+        String refreshToken = "validRefreshToken";
+        AccessTokenResponse response = new AccessTokenResponse("newAccessToken");
+
+        when(authService.refresh(refreshToken)).thenReturn(response);
+
+        // when & then
+        mockMvc.perform(post("/api/v1/auth/refresh")
+                        .cookie(new Cookie("refreshToken", refreshToken)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("토큰이 재발급되었습니다."))
+                .andExpect(jsonPath("$.data.accessToken").value("newAccessToken"))
                 .andExpect(jsonPath("$.success").value(true));
     }
 }

--- a/src/test/java/org/example/oddventure/domain/auth/unit/AuthServiceTest.java
+++ b/src/test/java/org/example/oddventure/domain/auth/unit/AuthServiceTest.java
@@ -110,6 +110,7 @@ public class AuthServiceTest {
         when(jwtUtil.createRefreshToken(user.getId())).thenReturn("refreshToken");
 
         // redis Mocking
+        @SuppressWarnings("unchecked")
         ValueOperations<String, String> operations = mock(ValueOperations.class);
         when(redisTemplate.opsForValue()).thenReturn(operations);
 

--- a/src/test/java/org/example/oddventure/domain/auth/unit/AuthServiceTest.java
+++ b/src/test/java/org/example/oddventure/domain/auth/unit/AuthServiceTest.java
@@ -4,6 +4,7 @@ import static org.example.oddventure.domain.auth.jwt.JwtConstants.REFRESH_TOKEN_
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -12,6 +13,8 @@ import static org.mockito.Mockito.when;
 import java.util.Optional;
 import org.example.oddventure.domain.auth.dto.request.LoginRequest;
 import org.example.oddventure.domain.auth.dto.request.SignupRequest;
+import org.example.oddventure.domain.auth.dto.request.WithdrawRequest;
+import org.example.oddventure.domain.auth.dto.response.AccessTokenResponse;
 import org.example.oddventure.domain.auth.dto.response.LoginResponse;
 import org.example.oddventure.domain.auth.dto.response.SignupResponse;
 import org.example.oddventure.domain.auth.exception.AuthException;
@@ -165,5 +168,126 @@ public class AuthServiceTest {
 
         // then
         verify(redisTemplate).delete(REFRESH_TOKEN_PREFIX + userId);
+    }
+
+    @Test
+    @DisplayName("회원 탈퇴 성공")
+    void withdraw_success() {
+
+        // given
+        Long userId = 1L;
+        WithdrawRequest request = new WithdrawRequest("correctPassword");
+        User user = User.builder()
+                .username("hello")
+                .email("hello@naver.com")
+                .password("$2a$10$eB9vYJzqZK8Zb3Q9gFZJ9uK0xE9gUuZzT1eYwKJvZzFzYxOqL9rP3O")
+                .userRole(UserRole.ROLE_USER)
+                .build();
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches(request.password(), user.getPassword())).thenReturn(true);
+
+        // when
+        authService.withdraw(userId, request);
+
+        // then
+        assertTrue(user.isDeleted());
+        verify(redisTemplate).delete(REFRESH_TOKEN_PREFIX + userId);
+    }
+
+    @Test
+    @DisplayName("회원 탈퇴 실패 - 비밀번호 불일치")
+    void withdraw_fail_incorrect_password() {
+
+        // given
+        Long userId = 1L;
+        WithdrawRequest request = new WithdrawRequest("wrongPassword");
+        User user = User.builder()
+                .username("hello")
+                .email("hello@naver.com")
+                .password("$2a$10$eB9vYJzqZK8Zb3Q9gFZJ9uK0xE9gUuZzT1eYwKJvZzFzYxOqL9rP3O")
+                .userRole(UserRole.ROLE_USER)
+                .build();
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches(request.password(), user.getPassword())).thenReturn(false);
+
+        // when & then
+        assertThrows(InvalidUserException.class, () -> authService.withdraw(userId, request));
+    }
+
+    @Test
+    @DisplayName("회원 탈퇴 실패 - 이미 탈퇴된 사용자")
+    void withdraw_fail_already_deleted() {
+
+        // given
+        Long userId = 1L;
+        WithdrawRequest request = new WithdrawRequest("correctPassword");
+        User user = User.builder()
+                .username("hello")
+                .email("hello@naver.com")
+                .password("$2a$10$eB9vYJzqZK8Zb3Q9gFZJ9uK0xE9gUuZzT1eYwKJvZzFzYxOqL9rP3O")
+                .userRole(UserRole.ROLE_USER)
+                .build();
+        user.delete();
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches(request.password(), user.getPassword())).thenReturn(true);
+
+        // when & then
+        assertThrows(InvalidUserException.class, () -> authService.withdraw(userId, request));
+    }
+
+    @Test
+    @DisplayName("토큰 재발급 성공")
+    void refresh_success() {
+
+        // given
+        String refreshToken = "validRefreshToken";
+        Long userId = 1L;
+        String newAccessToken = "newAccessToken";
+
+        when(jwtUtil.validateToken(refreshToken)).thenReturn(true);
+        when(jwtUtil.extractUserId(refreshToken)).thenReturn(userId);
+        when(jwtUtil.extractUserRole(refreshToken)).thenReturn(UserRole.ROLE_USER);
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(valueOperations.get(REFRESH_TOKEN_PREFIX + userId)).thenReturn(refreshToken);
+        when(jwtUtil.createAccessToken(userId, UserRole.ROLE_USER)).thenReturn(newAccessToken);
+
+        // when
+        AccessTokenResponse response = authService.refresh(refreshToken);
+
+        // then
+        assertNotNull(response);
+        assertEquals(newAccessToken, response.accessToken());
+    }
+
+    @Test
+    @DisplayName("토큰 재발급 실패 - 유효하지 않은 토큰")
+    void refresh_fail_invalid_token() {
+
+        // given
+        String refreshToken = "invalidToken";
+        when(jwtUtil.validateToken(refreshToken)).thenReturn(false);
+
+        // when & then
+        assertThrows(AuthException.class, () -> authService.refresh(refreshToken));
+    }
+
+    @Test
+    @DisplayName("토큰 재발급 실패 - 저장된 토큰과 불일치")
+    void refresh_fail_token_mismatch() {
+
+        // given
+        String refreshToken = "validRefreshToken";
+        Long userId = 1L;
+
+        when(jwtUtil.validateToken(refreshToken)).thenReturn(true);
+        when(jwtUtil.extractUserId(refreshToken)).thenReturn(userId);
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(valueOperations.get(REFRESH_TOKEN_PREFIX + userId)).thenReturn("differentToken");
+
+        // when & then
+        assertThrows(AuthException.class, () -> authService.refresh(refreshToken));
     }
 }

--- a/src/test/java/org/example/oddventure/domain/auth/unit/PasswordValidatorTest.java
+++ b/src/test/java/org/example/oddventure/domain/auth/unit/PasswordValidatorTest.java
@@ -30,4 +30,9 @@ public class PasswordValidatorTest {
     void missingSpecialCharacter() {
         assertFalse(passwordValidator.isValid("hello123", null));
     }
+
+    @Test
+    void nullPassword() {
+        assertFalse(passwordValidator.isValid(null, null));
+    }
 }


### PR DESCRIPTION
## 📝 작업 내용
- 회원가입, 토큰재발급 API 구현 및 테스트 코드 작성
- AOP기반 사용자 검증 어노테이션 추가
- BaseEntity에 softDelete 구현 및 그로 인한 코드 수정
- JwtUtil 테스트 코드 작성
- 리프레시 토큰 redis(검증용)와 더불어 쿠키(전달용)에도 저장
- 필터 내부 예외 응답 → 공통 응답 포맷에 맞춰 리팩토링

## 🔗 연관된 이슈
Related to: #41

## ✅ PR 유형
- [x] 새로운 기능 추가
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [x] 파일 혹은 폴더명 수정 및 삭제
