### PR TITLE
docs: Auth 도메인 REST Docs 적용

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -3,6 +3,116 @@
 :toclevels: 2
 :sectnums:
 :source-highlighter: highlightjs
+:icons: font
+
+== 인증 API (Auth API)
+
+=== 1️⃣ 회원가입 (POST /api/v1/auth/signup)
+
+새로운 사용자를 회원으로 등록합니다.
+요청 시 이름, 이메일, 비밀번호를 입력해야 하며, 중복된 이메일은 사용할 수 없습니다.
+
+==== 요청 예시
+include::{snippets}/auth-controller-test/signup_success/http-request.adoc[]
+
+==== 응답 예시
+include::{snippets}/auth-controller-test/signup_success/http-response.adoc[]
+
+==== 요청 필드 설명
+include::{snippets}/auth-controller-test/signup_success/request-fields.adoc[]
+
+==== 응답 필드 설명
+include::{snippets}/auth-controller-test/signup_success/response-fields.adoc[]
+
+---
+
+=== 2️⃣ 회원가입 실패 (이메일 중복 시)
+
+이미 등록된 이메일로 회원가입을 시도할 경우 실패합니다.
+
+==== 요청 예시
+include::{snippets}/auth-controller-test/signup_fail_exists_email/http-request.adoc[]
+
+==== 응답 예시
+include::{snippets}/auth-controller-test/signup_fail_exists_email/http-response.adoc[]
+
+==== 요청 필드 설명
+include::{snippets}/auth-controller-test/signup_fail_exists_email/request-fields.adoc[]
+
+==== 응답 필드 설명
+include::{snippets}/auth-controller-test/signup_fail_exists_email/response-fields.adoc[]
+
+---
+
+=== 3️⃣ 로그인 (POST /api/v1/auth/login)
+
+등록된 이메일과 비밀번호로 로그인합니다.
+로그인이 성공하면 AccessToken과 RefreshToken이 발급됩니다.
+
+==== 요청 예시
+include::{snippets}/auth-controller-test/login/http-request.adoc[]
+
+==== 응답 예시
+include::{snippets}/auth-controller-test/login/http-response.adoc[]
+
+==== 요청 필드 설명
+include::{snippets}/auth-controller-test/login/request-fields.adoc[]
+
+==== 응답 필드 설명
+include::{snippets}/auth-controller-test/login/response-fields.adoc[]
+
+---
+
+=== 4️⃣ 로그아웃 (POST /api/v1/auth/logout)
+
+현재 로그인된 사용자의 세션(토큰)을 무효화하여 로그아웃합니다.
+`Authorization` 헤더 또는 인증된 사용자 정보가 필요합니다.
+
+==== 요청 예시
+include::{snippets}/auth-controller-test/logout/http-request.adoc[]
+
+==== 응답 예시
+include::{snippets}/auth-controller-test/logout/http-response.adoc[]
+
+==== 응답 필드 설명
+include::{snippets}/auth-controller-test/logout/response-fields.adoc[]
+
+---
+
+=== 5️⃣ 회원 탈퇴 (DELETE /api/v1/auth/withdraw)
+
+현재 로그인된 사용자를 탈퇴 처리합니다.
+비밀번호를 재입력해야 하며, 탈퇴 시 모든 사용자 데이터가 삭제됩니다.
+
+==== 요청 예시
+include::{snippets}/auth-controller-test/withdraw_success/http-request.adoc[]
+
+==== 응답 예시
+include::{snippets}/auth-controller-test/withdraw_success/http-response.adoc[]
+
+==== 요청 필드 설명
+include::{snippets}/auth-controller-test/withdraw_success/request-fields.adoc[]
+
+==== 응답 필드 설명
+include::{snippets}/auth-controller-test/withdraw_success/response-fields.adoc[]
+
+---
+
+=== 6️⃣ 토큰 재발급 (POST /api/v1/auth/refresh)
+
+만료된 AccessToken을 갱신하기 위해 RefreshToken을 사용합니다.
+RefreshToken은 쿠키에 포함되어야 합니다.
+
+==== 요청 예시
+include::{snippets}/auth-controller-test/refresh_success/http-request.adoc[]
+
+==== 응답 예시
+include::{snippets}/auth-controller-test/refresh_success/http-response.adoc[]
+
+==== 응답 필드 설명
+include::{snippets}/auth-controller-test/refresh_success/response-fields.adoc[]
+
+---
 
 == 베팅 API (Bet API)
 
@@ -46,4 +156,3 @@ include::{snippets}/bet-controller-test/get-bet_success/http-response.adoc[]
 ==== 응답 필드 설명
 include::{snippets}/bet-controller-test/get-bet_success/response-fields.adoc[]
 
-:icons: font

--- a/src/test/java/org/example/oddventure/base/restdocs/RestDocsTestSupport.java
+++ b/src/test/java/org/example/oddventure/base/restdocs/RestDocsTestSupport.java
@@ -1,0 +1,38 @@
+package org.example.oddventure.base.restdocs;
+
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+@ExtendWith(RestDocumentationExtension.class)
+public abstract class RestDocsTestSupport {
+
+    protected MockMvc mockMvc;
+    protected RestDocumentationResultHandler restDocs;
+
+    @BeforeEach
+    void setup(WebApplicationContext context, RestDocumentationContextProvider restDocumentation) {
+        this.restDocs = MockMvcRestDocumentation.document("{class-name}/{method-name}",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()));
+
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
+                .addFilter(new CharacterEncodingFilter("UTF-8", true))
+                .apply(MockMvcRestDocumentation.documentationConfiguration(restDocumentation))
+                .apply(SecurityMockMvcConfigurers.springSecurity())
+                .alwaysDo(restDocs)
+                .build();
+    }
+}

--- a/src/test/java/org/example/oddventure/base/restdocs/RestDocsUtils.java
+++ b/src/test/java/org/example/oddventure/base/restdocs/RestDocsUtils.java
@@ -1,0 +1,78 @@
+package org.example.oddventure.base.restdocs;
+
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.restdocs.snippet.Snippet;
+
+public class RestDocsUtils {
+
+    // 공통 성공 응답 필드 (data 제외)
+    private static List<FieldDescriptor> commonSuccessResponseFields() {
+        List<FieldDescriptor> fields = new ArrayList<>();
+        fields.add(fieldWithPath("httpStatus").description("HTTP 상태 코드"));
+        fields.add(fieldWithPath("code").description("응답 코드"));
+        fields.add(fieldWithPath("success").description("성공 여부"));
+        fields.add(fieldWithPath("message").description("응답 메시지"));
+        fields.add(fieldWithPath("timestamp").description("응답 시간"));
+        return fields;
+    }
+
+    // 공통 에러 응답 필드
+    private static List<FieldDescriptor> commonErrorResponseFields() {
+        List<FieldDescriptor> fields = new ArrayList<>();
+        fields.add(fieldWithPath("httpStatus").description("HTTP 상태 코드"));
+        fields.add(fieldWithPath("code").description("응답 코드"));
+        fields.add(fieldWithPath("success").description("성공 여부"));
+        fields.add(fieldWithPath("message").description("오류 메시지"));
+        fields.add(fieldWithPath("data").description("에러 응답의 경우 항상 null").optional());
+        fields.add(fieldWithPath("timestamp").description("응답 시간"));
+        fields.add(fieldWithPath("requestUrl").description("요청 URL"));
+        return fields;
+    }
+
+    /**
+     * 공통 성공 응답 필드 + {@code data} 내부의 필드를 병합한 {@code Snippet}을 생성
+     *
+     * <p>사용 예시</p>
+     * <pre>{@code
+     * .andDo(restDocs.document(
+     *      requestFields(...),
+     *      RestDocsUtils.successWithDataFields(
+     *          fieldWithPath("data.userId").description("회원 ID"),
+     *          fieldWithPath("data.username").description("회원 이름")
+     *      )
+     * ));
+     * }</pre>
+     */
+    public static Snippet successWithDataFields(FieldDescriptor... dataFields) {
+        List<FieldDescriptor> fields = commonSuccessResponseFields();
+
+        if (dataFields == null || dataFields.length == 0) {
+            fields.add(fieldWithPath("data").description("응답 데이터 (null일 수 있음)").optional());
+        } else {
+            fields.add(fieldWithPath("data").description("응답 데이터"));
+            fields.addAll(List.of(dataFields));
+        }
+
+        return responseFields(fields);
+    }
+
+    /**
+     * 공통 에러 응답 필드에 대한 {@code Snippet} 생성
+     *
+     * <p>사용 예시</p>
+     * <pre>{@code
+     * .andDo(restDocs.document(
+     *     requestFields(...),
+     *     RestDocsUtils.errorResponseFields()
+     * ));
+     * }</pre>
+     */
+    public static Snippet errorResponseFields() {
+        return responseFields(commonErrorResponseFields());
+    }
+}

--- a/src/test/java/org/example/oddventure/domain/auth/unit/AuthControllerTest.java
+++ b/src/test/java/org/example/oddventure/domain/auth/unit/AuthControllerTest.java
@@ -2,6 +2,8 @@ package org.example.oddventure.domain.auth.unit;
 
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -12,6 +14,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.Cookie;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import org.example.oddventure.base.restdocs.RestDocsTestSupport;
+import org.example.oddventure.base.restdocs.RestDocsUtils;
 import org.example.oddventure.domain.auth.config.SecurityConfig;
 import org.example.oddventure.domain.auth.controller.AuthController;
 import org.example.oddventure.domain.auth.dto.AuthUser;
@@ -35,14 +39,11 @@ import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
 
 @WebMvcTest(AuthController.class)
 @Import({SecurityConfig.class, JwtUtil.class})
-public class AuthControllerTest {
-
-    @Autowired
-    private MockMvc mockMvc;
+public class AuthControllerTest extends RestDocsTestSupport {
 
     @MockitoBean
     private AuthService authService;
@@ -66,15 +67,32 @@ public class AuthControllerTest {
         );
         when(authService.signup(request)).thenReturn(response);
 
-        // when & then
-        mockMvc.perform(post("/api/v1/auth/signup")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isCreated())
+        // when
+        ResultActions result = mockMvc.perform(post("/api/v1/auth/signup")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)));
+
+        // then
+        result.andExpect(status().isCreated())
                 .andExpect(jsonPath("$.message").value("회원가입이 완료되었습니다."))
                 .andExpect(jsonPath("$.data.userId").value(userId))
                 .andExpect(jsonPath("$.data.username").value("hello"))
-                .andExpect(jsonPath("$.data.point").value("1000"));
+                .andExpect(jsonPath("$.data.point").value("1000"))
+                .andDo(restDocs.document(
+                        requestFields(
+                                fieldWithPath("username").description("사용자 이름"),
+                                fieldWithPath("email").description("사용자 이메일"),
+                                fieldWithPath("password").description("비밀번호")
+                        ),
+                        RestDocsUtils.successWithDataFields(
+                                fieldWithPath("data.userId").description("회원 ID"),
+                                fieldWithPath("data.username").description("회원 이름"),
+                                fieldWithPath("data.email").description("회원 이메일"),
+                                fieldWithPath("data.role").description("회원 권한"),
+                                fieldWithPath("data.point").description("초기 포인트"),
+                                fieldWithPath("data.createdAt").description("회원가입 일시")
+                        )
+                ));
     }
 
     @Test
@@ -82,15 +100,24 @@ public class AuthControllerTest {
     void signup_fail_exists_email() throws Exception {
         // given
         SignupRequest request = new SignupRequest("hello", "hello@naver.com", "hello123!@#");
-
         when(authService.signup(request)).thenThrow(new UserException(UserErrorCode.ALREADY_EXIST_EMAIL));
 
-        // when & then
-        mockMvc.perform(post("/api/v1/auth/signup")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isConflict())
-                .andExpect(jsonPath("$.message").value("이미 존재하는 이메일 입니다."));
+        // when
+        ResultActions result = mockMvc.perform(post("/api/v1/auth/signup")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)));
+
+        // then
+        result.andExpect(status().isConflict())
+                .andExpect(jsonPath("$.message").value(UserErrorCode.ALREADY_EXIST_EMAIL.getMessage()))
+                .andDo(restDocs.document(
+                        requestFields(
+                                fieldWithPath("username").description("사용자 이름"),
+                                fieldWithPath("email").description("사용자 이메일"),
+                                fieldWithPath("password").description("비밀번호")
+                        ),
+                        RestDocsUtils.errorResponseFields()
+                ));
     }
 
     @Test
@@ -102,14 +129,25 @@ public class AuthControllerTest {
         LoginResponse response = new LoginResponse("accessToken", "refreshToken");
         when(authService.login(request)).thenReturn(response);
 
-        // when & then
-        mockMvc.perform(post("/api/v1/auth/login")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isOk())
+        // when
+        ResultActions result = mockMvc.perform(post("/api/v1/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)));
+        // then
+        result.andExpect(status().isOk())
                 .andExpect(jsonPath("$.message").value("로그인 되었습니다."))
                 .andExpect(jsonPath("$.data.accessToken").value("accessToken"))
-                .andExpect(jsonPath("$.data.refreshToken").value("refreshToken"));
+                .andExpect(jsonPath("$.data.refreshToken").value("refreshToken"))
+                .andDo(restDocs.document(
+                        requestFields(
+                                fieldWithPath("email").description("사용자 이메일"),
+                                fieldWithPath("password").description("비밀번호")
+                        ),
+                        RestDocsUtils.successWithDataFields(
+                                fieldWithPath("data.accessToken").description("액세스 토큰"),
+                                fieldWithPath("data.refreshToken").description("리프레시 토큰")
+                        )
+                ));
     }
 
     @Test
@@ -120,13 +158,15 @@ public class AuthControllerTest {
         AuthUser authUser = new AuthUser(1L, UserRole.ROLE_USER);
         doNothing().when(authService).logout(authUser.id());
 
-        // when & then
-        mockMvc.perform(post("/api/v1/auth/logout")
-                        .with(authentication(
-                                new UsernamePasswordAuthenticationToken(authUser, null, authUser.getAuthorities()))))
-                .andExpect(status().isOk())
+        // when
+        ResultActions result = mockMvc.perform(post("/api/v1/auth/logout")
+                .with(authentication(
+                        new UsernamePasswordAuthenticationToken(authUser, null, authUser.getAuthorities()))));
+        // then
+        result.andExpect(status().isOk())
                 .andExpect(jsonPath("$.message").value("로그아웃 되었습니다."))
-                .andExpect(jsonPath("$.success").value(true));
+                .andExpect(jsonPath("$.success").value(true))
+                .andDo(restDocs.document(RestDocsUtils.successWithDataFields()));
     }
 
     @Test
@@ -139,16 +179,23 @@ public class AuthControllerTest {
 
         doNothing().when(authService).withdraw(authUser.id(), request);
 
-        // when & then
-        mockMvc.perform(delete("/api/v1/auth/withdraw")
-                        .with(authentication(
-                                new UsernamePasswordAuthenticationToken(authUser, null, authUser.getAuthorities())))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request))
-                )
-                .andExpect(status().isOk())
+        // when
+        ResultActions result = mockMvc.perform(delete("/api/v1/auth/withdraw")
+                .with(authentication(
+                        new UsernamePasswordAuthenticationToken(authUser, null, authUser.getAuthorities())))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)));
+
+        // then
+        result.andExpect(status().isOk())
                 .andExpect(jsonPath("$.message").value("회원탈퇴 되었습니다."))
-                .andExpect(jsonPath("$.success").value(true));
+                .andExpect(jsonPath("$.success").value(true))
+                .andDo(restDocs.document(
+                        requestFields(
+                                fieldWithPath("password").description("비밀번호 확인")
+                        ),
+                        RestDocsUtils.successWithDataFields()
+                ));
     }
 
     @Test
@@ -161,12 +208,18 @@ public class AuthControllerTest {
 
         when(authService.refresh(refreshToken)).thenReturn(response);
 
-        // when & then
-        mockMvc.perform(post("/api/v1/auth/refresh")
-                        .cookie(new Cookie("refreshToken", refreshToken)))
-                .andExpect(status().isOk())
+        // when
+        ResultActions result = mockMvc.perform(post("/api/v1/auth/refresh")
+                .cookie(new Cookie("refreshToken", refreshToken)));
+        // then
+        result.andExpect(status().isOk())
                 .andExpect(jsonPath("$.message").value("토큰이 재발급되었습니다."))
                 .andExpect(jsonPath("$.data.accessToken").value("newAccessToken"))
-                .andExpect(jsonPath("$.success").value(true));
+                .andExpect(jsonPath("$.success").value(true))
+                .andDo(restDocs.document(
+                        RestDocsUtils.successWithDataFields(
+                                fieldWithPath("data.accessToken").description("새로 발급된 액세스 토큰")
+                        )
+                ));
     }
 }


### PR DESCRIPTION
## 📝 작업 내용
- AuthControllerTest에 Spring REST Docs 문서화 적용
- RestDocsTestSupport 클래스 추가 → MockMvc, Security, REST Docs 공통 설정 분리
- RestDocsUtils 클래스 추가 → 공통 응답 필드(httpStatus, code, message, data, timestamp 등) 관리 및 재사용

## ✅ PR 유형
- [x] 새로운 기능 추가
- [x] 코드 리팩토링
