### PR TITLE
docs: Match 도메인 REST Docs 적용

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -156,3 +156,56 @@ include::{snippets}/bet-controller-test/get-bet_success/http-response.adoc[]
 ==== 응답 필드 설명
 include::{snippets}/bet-controller-test/get-bet_success/response-fields.adoc[]
 
+---
+
+== 경기 API (Match API)
+
+=== 1️⃣ 경기 목록 조회 (GET /api/v1/matches)
+
+등록된 경기의 전체 목록을 페이지 형태로 조회합니다.
+요청 시 페이지 번호(`page`)와 크기(`size`)를 전달할 수 있습니다.
+경기는 기본적으로 `startTime` 기준 오름차순으로 정렬됩니다.
+
+==== 요청 예시
+include::{snippets}/match-controller-test/get-matches_success/http-request.adoc[]
+
+==== 응답 예시
+include::{snippets}/match-controller-test/get-matches_success/http-response.adoc[]
+
+==== 응답 필드 설명
+include::{snippets}/match-controller-test/get-matches_success/response-fields.adoc[]
+
+---
+
+=== 2️⃣ 경기 상세 조회 (GET /api/v1/matches/{matchId})
+
+특정 경기의 상세 정보를 조회합니다.
+경기 ID(`matchId`)를 경로 변수로 전달해야 합니다.
+
+==== 요청 예시
+include::{snippets}/match-controller-test/get-match-detail_success/http-request.adoc[]
+
+==== 응답 예시
+include::{snippets}/match-controller-test/get-match-detail_success/http-response.adoc[]
+
+==== 응답 필드 설명
+include::{snippets}/match-controller-test/get-match-detail_success/response-fields.adoc[]
+
+---
+
+=== 3️⃣ 경기 검색 (POST /api/v1/matches/search)
+
+경기 이름, 상태, 날짜 등 검색 조건을 바탕으로 경기를 조회합니다.
+검색 조건은 JSON Body로 전달하며, 페이징 처리와 함께 결과를 반환합니다.
+
+==== 요청 예시
+include::{snippets}/match-controller-test/search-matches_success/http-request.adoc[]
+
+==== 응답 예시
+include::{snippets}/match-controller-test/search-matches_success/http-response.adoc[]
+
+==== 요청 필드 설명
+include::{snippets}/match-controller-test/search-matches_success/request-fields.adoc[]
+
+==== 응답 필드 설명
+include::{snippets}/match-controller-test/search-matches_success/response-fields.adoc[]

--- a/src/main/java/org/example/oddventure/common/dto/response/ApiPageResponse.java
+++ b/src/main/java/org/example/oddventure/common/dto/response/ApiPageResponse.java
@@ -5,18 +5,23 @@ import java.time.LocalDateTime;
 import java.util.List;
 import lombok.Getter;
 import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 @Getter
-@JsonPropertyOrder({"success", "message", "data", "timestamp"})
+@JsonPropertyOrder({"httpStatus", "code", "success", "message", "data", "timestamp"})
 public class ApiPageResponse<T> {
 
+    private final HttpStatus httpStatus;
+    private final int code;
     private final boolean success;
     private final String message;
     private final PageData<T> data;
     private final LocalDateTime timestamp;
 
-    private ApiPageResponse(PageData<T> data, String message) {
+    private ApiPageResponse(HttpStatus httpStatus, int code, PageData<T> data, String message) {
+        this.httpStatus = httpStatus;
+        this.code = code;
         this.success = true;
         this.message = message;
         this.data = data;
@@ -30,7 +35,8 @@ public class ApiPageResponse<T> {
      * @return HTTP 200 OK 응답과 함께 성공 데이터가 포함된 ApiPageResponse
      */
     public static <T> ResponseEntity<ApiPageResponse<T>> success(Page<T> page, String message) {
-        return ResponseEntity.ok(new ApiPageResponse<>(PageData.from(page), message));
+        return ResponseEntity.ok(
+                new ApiPageResponse<>(HttpStatus.OK, HttpStatus.OK.value(), PageData.from(page), message));
     }
 
     @Getter

--- a/src/test/java/org/example/oddventure/domain/bet/unit/BetControllerTest.java
+++ b/src/test/java/org/example/oddventure/domain/bet/unit/BetControllerTest.java
@@ -1,12 +1,8 @@
 package org.example.oddventure.domain.bet.unit;
 
 import static org.mockito.Mockito.when;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
@@ -16,10 +12,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.math.BigDecimal;
-import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.example.oddventure.base.WithMockAuthUser;
+import org.example.oddventure.base.restdocs.RestDocsTestSupport;
+import org.example.oddventure.base.restdocs.RestDocsUtils;
 import org.example.oddventure.domain.auth.config.SecurityConfig;
 import org.example.oddventure.domain.auth.jwt.JwtUtil;
 import org.example.oddventure.domain.bet.controller.BetController;
@@ -31,10 +28,8 @@ import org.example.oddventure.domain.bet.enums.SelectedTeam;
 import org.example.oddventure.domain.bet.service.BetService;
 import org.example.oddventure.domain.match.dto.response.MatchBetResponse;
 import org.example.oddventure.domain.user.enums.UserRole;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
@@ -43,46 +38,18 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
-import org.springframework.restdocs.RestDocumentationContextProvider;
-import org.springframework.restdocs.RestDocumentationExtension;
-import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
-import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
-import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.web.context.WebApplicationContext;
-import org.springframework.web.filter.CharacterEncodingFilter;
 
 @WebMvcTest(BetController.class)
-@ExtendWith(RestDocumentationExtension.class)
 @Import({SecurityConfig.class, JwtUtil.class})
 @WithMockAuthUser(userId = 1, role = UserRole.ROLE_USER)
-public class BetControllerTest {
+public class BetControllerTest extends RestDocsTestSupport {
 
     @MockitoBean
     private BetService betService;
 
     @Autowired
     private ObjectMapper objectMapper;
-
-    private MockMvc mockMvc;
-
-    private RestDocumentationResultHandler restDocs;
-
-    @BeforeEach
-    void setup(WebApplicationContext webApplicationContext, RestDocumentationContextProvider restDocumentation) {
-        this.restDocs = MockMvcRestDocumentation.document("{class-name}/{method-name}",
-                preprocessRequest(prettyPrint()),
-                preprocessResponse(prettyPrint()));
-
-        mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
-                .addFilter(new CharacterEncodingFilter(StandardCharsets.UTF_8.name(), true))
-                .apply(MockMvcRestDocumentation.documentationConfiguration(restDocumentation))
-                .apply(SecurityMockMvcConfigurers.springSecurity())
-                .alwaysDo(restDocs) // 디폴트 설정
-                .build();
-    }
 
     @Test
     @DisplayName("POST /bets - 베팅 생성 성공")
@@ -116,20 +83,14 @@ public class BetControllerTest {
                                 fieldWithPath("selectedTeam").description("선택한 팀"),
                                 fieldWithPath("betAmount").description("베팅 금액")
                         ),
-                        responseFields(
-                                fieldWithPath("httpStatus").description("HTTP 상태 코드"),
-                                fieldWithPath("code").description("응답 코드"),
-                                fieldWithPath("success").description("성공 여부"),
-                                fieldWithPath("message").description("응답 메시지"),
-                                fieldWithPath("data").description("응답 데이터"),
+                        RestDocsUtils.successWithDataFields(
                                 fieldWithPath("data.betId").description("베팅 ID"),
                                 fieldWithPath("data.userId").description("사용자 ID"),
                                 fieldWithPath("data.selectedTeam").description("선택한 팀"),
                                 fieldWithPath("data.selectedTeamName").description("선택한 팀 이름"),
                                 fieldWithPath("data.betAmount").description("베팅 금액"),
                                 fieldWithPath("data.oddsAtBetting").description("베팅 시점 배당률"),
-                                fieldWithPath("data.userPointAfter").description("사용자 포인트 잔액"),
-                                fieldWithPath("timestamp").description("응답 시간")
+                                fieldWithPath("data.userPointAfter").description("사용자 포인트 잔액")
                         )
                 ));
     }
@@ -157,16 +118,11 @@ public class BetControllerTest {
                         pathParameters(
                                 parameterWithName("betId").description("베팅 ID")
                         ),
-                        responseFields(
-                                fieldWithPath("httpStatus").description("HTTP 상태 코드"),
-                                fieldWithPath("code").description("응답 코드"),
-                                fieldWithPath("success").description("성공 여부"),
-                                fieldWithPath("message").description("응답 메시지"),
-                                fieldWithPath("data").description("응답 데이터"),
+                        RestDocsUtils.successWithDataFields(
                                 fieldWithPath("data.betId").description("베팅 ID"),
                                 fieldWithPath("data.refundAmount").description("환불 금액"),
-                                fieldWithPath("data.userPointAfter").description("사용자 포인트 잔액"),
-                                fieldWithPath("timestamp").description("응답 시간"))
+                                fieldWithPath("data.userPointAfter").description("사용자 포인트 잔액")
+                        )
                 ));
     }
 
@@ -207,26 +163,22 @@ public class BetControllerTest {
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andDo(restDocs.document(
-                                responseFields(
-                                        fieldWithPath("success").description("성공 여부"),
-                                        fieldWithPath("message").description("응답 메시지"),
-                                        fieldWithPath("data").description("페이징 응답 데이터"),
-                                        fieldWithPath("data.content[].betId").description("베팅 ID"),
-                                        fieldWithPath("data.content[].matchBetResponse.matchId").description("경기 ID"),
-                                        fieldWithPath("data.content[].matchBetResponse.teamA").description("팀 A"),
-                                        fieldWithPath("data.content[].matchBetResponse.teamB").description("팀 B"),
-                                        fieldWithPath("data.content[].matchBetResponse.startTime").description("경기 시작 시간"),
-                                        fieldWithPath("data.content[].selectedTeam").description("선택한 팀"),
-                                        fieldWithPath("data.content[].betAmount").description("베팅 금액"),
-                                        fieldWithPath("data.content[].oddsAtBetting").description("베팅 시점 배당률"),
-                                        fieldWithPath("data.content[].isWin").description("베팅 성공 여부"),
-                                        fieldWithPath("data.content[].createdAt").description("베팅 생성 시간"),
-                                        fieldWithPath("data.totalElements").description("전체 데이터 개수"),
-                                        fieldWithPath("data.totalPages").description("총 페이지 수"),
-                                        fieldWithPath("data.size").description("페이지 당 데이터 개수"),
-                                        fieldWithPath("data.number").description("현재 페이지 번호"),
-                                        fieldWithPath("timestamp").description("응답 시간"))
+                        RestDocsUtils.successWithDataFields(
+                                fieldWithPath("data.content[].betId").description("베팅 ID"),
+                                fieldWithPath("data.content[].matchBetResponse.matchId").description("경기 ID"),
+                                fieldWithPath("data.content[].matchBetResponse.teamA").description("팀 A"),
+                                fieldWithPath("data.content[].matchBetResponse.teamB").description("팀 B"),
+                                fieldWithPath("data.content[].matchBetResponse.startTime").description("경기 시작 시간"),
+                                fieldWithPath("data.content[].selectedTeam").description("선택한 팀"),
+                                fieldWithPath("data.content[].betAmount").description("베팅 금액"),
+                                fieldWithPath("data.content[].oddsAtBetting").description("베팅 시점 배당률"),
+                                fieldWithPath("data.content[].isWin").description("베팅 성공 여부"),
+                                fieldWithPath("data.content[].createdAt").description("베팅 생성 시간"),
+                                fieldWithPath("data.totalElements").description("전체 데이터 개수"),
+                                fieldWithPath("data.totalPages").description("총 페이지 수"),
+                                fieldWithPath("data.size").description("페이지 당 데이터 개수"),
+                                fieldWithPath("data.number").description("현재 페이지 번호")
                         )
-                );
+                ));
     }
 }

--- a/src/test/java/org/example/oddventure/domain/match/unit/MatchControllerTest.java
+++ b/src/test/java/org/example/oddventure/domain/match/unit/MatchControllerTest.java
@@ -1,6 +1,9 @@
-package org.example.oddventure.domain.match.controller;
+package org.example.oddventure.domain.match.unit;
 
 import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -10,8 +13,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
+import org.example.oddventure.base.restdocs.RestDocsTestSupport;
+import org.example.oddventure.base.restdocs.RestDocsUtils;
 import org.example.oddventure.domain.auth.config.SecurityConfig;
 import org.example.oddventure.domain.auth.jwt.JwtUtil;
+import org.example.oddventure.domain.match.controller.MatchController;
 import org.example.oddventure.domain.match.dto.request.MatchSearchCondition;
 import org.example.oddventure.domain.match.dto.response.MatchResponse;
 import org.example.oddventure.domain.match.enums.MatchStatus;
@@ -30,16 +36,12 @@ import org.springframework.data.domain.Sort;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
 @WebMvcTest(MatchController.class)
 @Import({SecurityConfig.class, JwtUtil.class})
 @WithMockUser(roles = {"USER"})
-class MatchControllerTest {
-
-    @Autowired
-    private MockMvc mockMvc;
+class MatchControllerTest extends RestDocsTestSupport {
 
     @MockitoBean
     private MatchService matchService;
@@ -69,7 +71,7 @@ class MatchControllerTest {
     }
 
     @Test
-    @DisplayName("GET /matches - 경기 목록 조회 성공")
+    @DisplayName("GET /matches - 매치 목록 조회 성공")
     void getMatches_success() throws Exception {
         // given
         Pageable pageable = PageRequest.of(0, 10, Sort.by("startTime").ascending());
@@ -85,11 +87,32 @@ class MatchControllerTest {
         result.andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.content[0].matchId").value(1))
                 .andExpect(jsonPath("$.data.content[0].teamB").value("GEN.G"))
-                .andExpect(jsonPath("$.data.content[0].status").value("SCHEDULED"));
+                .andExpect(jsonPath("$.data.content[0].status").value("SCHEDULED"))
+                .andDo(restDocs.document(
+                        RestDocsUtils.successWithDataFields(
+                                fieldWithPath("data.content[].matchId").description("매치 ID"),
+                                fieldWithPath("data.content[].matchName").description("매치명"),
+                                fieldWithPath("data.content[].teamA").description("팀 A"),
+                                fieldWithPath("data.content[].teamB").description("팀 B"),
+                                fieldWithPath("data.content[].totalAmountA").description("팀 A 베팅 총액"),
+                                fieldWithPath("data.content[].totalAmountB").description("팀 B 베팅 총액"),
+                                fieldWithPath("data.content[].startTime").description("매치 시작 시간"),
+                                fieldWithPath("data.content[].endTime").description("매치 종료 시간"),
+                                fieldWithPath("data.content[].status").description("매치 상태"),
+                                fieldWithPath("data.content[].winner").description("승리 팀").optional(),
+                                fieldWithPath("data.content[].loser").description("패배 팀").optional(),
+                                fieldWithPath("data.content[].viewCount").description("조회수"),
+                                fieldWithPath("data.content[].createdAt").description("생성일시"),
+                                fieldWithPath("data.totalElements").description("전체 데이터 개수"),
+                                fieldWithPath("data.totalPages").description("총 페이지 수"),
+                                fieldWithPath("data.size").description("페이지당 데이터 개수"),
+                                fieldWithPath("data.number").description("현재 페이지 번호")
+                        )
+                ));
     }
 
     @Test
-    @DisplayName("GET /matches/{matchId} - 경기 상세 조회 성공")
+    @DisplayName("GET /matches/{matchId} - 매치 상세 조회 성공")
     void getMatchDetail_success() throws Exception {
         // given
         Long matchId = 1L;
@@ -102,11 +125,31 @@ class MatchControllerTest {
         result.andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.matchId").value(matchId))
                 .andExpect(jsonPath("$.data.teamA").value("T1"))
-                .andExpect(jsonPath("$.data.viewCount").value(153L));
+                .andExpect(jsonPath("$.data.viewCount").value(153L))
+                .andDo(restDocs.document(
+                        pathParameters(
+                                parameterWithName("matchId").description("매치 ID")
+                        ),
+                        RestDocsUtils.successWithDataFields(
+                                fieldWithPath("data.matchId").description("매치 ID"),
+                                fieldWithPath("data.matchName").description("매치명"),
+                                fieldWithPath("data.teamA").description("팀 A"),
+                                fieldWithPath("data.teamB").description("팀 B"),
+                                fieldWithPath("data.totalAmountA").description("팀 A 베팅 총액"),
+                                fieldWithPath("data.totalAmountB").description("팀 B 베팅 총액"),
+                                fieldWithPath("data.startTime").description("매치 시작 시간"),
+                                fieldWithPath("data.endTime").description("매치 종료 시간"),
+                                fieldWithPath("data.status").description("매치 상태"),
+                                fieldWithPath("data.winner").description("승리 팀").optional(),
+                                fieldWithPath("data.loser").description("패배 팀").optional(),
+                                fieldWithPath("data.viewCount").description("조회수"),
+                                fieldWithPath("data.createdAt").description("생성일시")
+                        )
+                ));
     }
 
     @Test
-    @DisplayName("POST /matches/search - 경기 검색 성공")
+    @DisplayName("POST /matches/search - 매치 검색 성공")
     void searchMatches_success() throws Exception {
         // given
         MatchSearchCondition condition = new MatchSearchCondition("", null, null);
@@ -124,6 +167,27 @@ class MatchControllerTest {
         // then
         result.andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.content[0].matchId").value(1))
-                .andExpect(jsonPath("$.data.content[0].teamB").value("GEN.G"));
+                .andExpect(jsonPath("$.data.content[0].teamB").value("GEN.G"))
+                .andDo(restDocs.document(
+                        RestDocsUtils.successWithDataFields(
+                                fieldWithPath("data.content[].matchId").description("매치 ID"),
+                                fieldWithPath("data.content[].matchName").description("매치명"),
+                                fieldWithPath("data.content[].teamA").description("팀 A"),
+                                fieldWithPath("data.content[].teamB").description("팀 B"),
+                                fieldWithPath("data.content[].totalAmountA").description("팀 A 베팅 총액"),
+                                fieldWithPath("data.content[].totalAmountB").description("팀 B 베팅 총액"),
+                                fieldWithPath("data.content[].startTime").description("매치 시작 시간"),
+                                fieldWithPath("data.content[].endTime").description("매치 종료 시간"),
+                                fieldWithPath("data.content[].status").description("매치 상태"),
+                                fieldWithPath("data.content[].winner").description("승리 팀").optional(),
+                                fieldWithPath("data.content[].loser").description("패배 팀").optional(),
+                                fieldWithPath("data.content[].viewCount").description("조회수"),
+                                fieldWithPath("data.content[].createdAt").description("생성일시"),
+                                fieldWithPath("data.totalElements").description("전체 데이터 개수"),
+                                fieldWithPath("data.totalPages").description("총 페이지 수"),
+                                fieldWithPath("data.size").description("페이지당 데이터 개수"),
+                                fieldWithPath("data.number").description("현재 페이지 번호")
+                        )
+                ));
     }
 }


### PR DESCRIPTION
## 📝 작업 내용
- Match 도메인 REST Docs 적용
- BetControllerTest 공통 유틸 적용 리팩토링
- ApiPageResponse httpStatus, code 필드 추가

## ✅ PR 유형
- [x] 새로운 기능 추가
- [x] 코드 리팩토링