### PR TITLE
feat: 매치 일정 연동 API

### DIFF
--- a/src/main/java/org/example/oddventure/common/config/WebClientConfig.java
+++ b/src/main/java/org/example/oddventure/common/config/WebClientConfig.java
@@ -9,13 +9,13 @@ import org.springframework.web.reactive.function.client.WebClient;
 @Configuration
 public class WebClientConfig {
 
-    @Value("${match-data.grid.central-data.base-url}")
+    @Value("${grid.central-data.base-url}")
     private String GRID_CENTRAL_BASE_URL;
 
-    @Value("${match-data.grid.live-data.base-url}")
+    @Value("${grid.live-data.base-url}")
     private String GRID_LIVE_BASE_URL;
 
-    @Value("${match-data.grid.api-key}")
+    @Value("${grid.api-key}")
     private String GRID_API_KEY;
 
     @Bean

--- a/src/main/java/org/example/oddventure/common/config/WebClientConfig.java
+++ b/src/main/java/org/example/oddventure/common/config/WebClientConfig.java
@@ -1,11 +1,14 @@
 package org.example.oddventure.common.config;
 
+import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.web.reactive.function.client.WebClient;
 
+@Log4j2
 @Configuration
 public class WebClientConfig {
 
@@ -20,10 +23,12 @@ public class WebClientConfig {
 
     @Bean
     public WebClient gridCentralClient() {
-        return WebClient.builder()
+        WebClient build = WebClient.builder()
                 .baseUrl(GRID_CENTRAL_BASE_URL)
-                .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + GRID_API_KEY)
+                .defaultHeader("x-api-key", GRID_API_KEY)
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                 .build();
+        return build;
     }
 
     @Bean

--- a/src/main/java/org/example/oddventure/common/config/WebClientConfig.java
+++ b/src/main/java/org/example/oddventure/common/config/WebClientConfig.java
@@ -1,0 +1,36 @@
+package org.example.oddventure.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+    @Value("${match-data.grid.central-data.base-url}")
+    private String GRID_CENTRAL_BASE_URL;
+
+    @Value("${match-data.grid.live-data.base-url}")
+    private String GRID_LIVE_BASE_URL;
+
+    @Value("${match-data.grid.api-key}")
+    private String GRID_API_KEY;
+
+    @Bean
+    public WebClient gridCentralClient() {
+        return WebClient.builder()
+                .baseUrl(GRID_CENTRAL_BASE_URL)
+                .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + GRID_API_KEY)
+                .build();
+    }
+
+    @Bean
+    public WebClient gridLiveClient() {
+        return WebClient.builder()
+                .baseUrl(GRID_LIVE_BASE_URL)
+                .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + GRID_API_KEY)
+                .build();
+    }
+}

--- a/src/main/java/org/example/oddventure/domain/admin/controller/AdminController.java
+++ b/src/main/java/org/example/oddventure/domain/admin/controller/AdminController.java
@@ -76,4 +76,11 @@ public class AdminController {
         PointAdjustResponse response = adminService.adjustUserPoints(userId, request);
         return ApiResponse.success(response, "포인트 지급에 성공했습니다.");
     }
+
+    // 매치 일정 연동
+    @PostMapping("/matches/fetch")
+    public ResponseEntity<ApiResponse<MatchAdminResponse>> fetchMatches() {
+        adminService.fetchMatches();
+        return ApiResponse.noContent("매치가 연동되었습니다.");
+    }
 }

--- a/src/main/java/org/example/oddventure/domain/admin/service/AdminService.java
+++ b/src/main/java/org/example/oddventure/domain/admin/service/AdminService.java
@@ -97,7 +97,7 @@ public class AdminService {
         );
     }
 
-    // 매치 일정 연
+    // 매치 일정 연동
     @Transactional
     public void fetchMatches() {
         List<MatchFetchResponse> fetchResponses = gridService.fetchMatches();

--- a/src/main/java/org/example/oddventure/domain/admin/service/AdminService.java
+++ b/src/main/java/org/example/oddventure/domain/admin/service/AdminService.java
@@ -1,5 +1,6 @@
 package org.example.oddventure.domain.admin.service;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.oddventure.domain.admin.dto.request.MatchCreateRequest;
@@ -10,6 +11,8 @@ import org.example.oddventure.domain.admin.dto.response.PointAdjustResponse;
 import org.example.oddventure.domain.admin.dto.response.UserAdminResponse;
 import org.example.oddventure.domain.admin.exception.AdminErrorCode;
 import org.example.oddventure.domain.admin.exception.AdminException;
+import org.example.oddventure.domain.grid.dto.response.MatchFetchResponse;
+import org.example.oddventure.domain.grid.service.GridService;
 import org.example.oddventure.domain.match.entity.Match;
 import org.example.oddventure.domain.match.repository.MatchRepository;
 import org.example.oddventure.domain.user.entity.User;
@@ -26,6 +29,7 @@ public class AdminService {
 
     private final MatchRepository matchRepository;
     private final UserRepository userRepository;
+    private final GridService gridService;
 
     // 매치 생성
     @Transactional
@@ -91,5 +95,23 @@ public class AdminService {
                 request.amount(),
                 user.getPoint()
         );
+    }
+
+    // 매치 일정 연
+    @Transactional
+    public void fetchMatches() {
+        List<MatchFetchResponse> fetchResponses = gridService.fetchMatches();
+
+        fetchResponses.stream()
+                .filter(dto -> !matchRepository.existsByFetchId(dto.fetchId()))
+                .filter(dto -> !dto.teamA().contains("TBD")) // 미정된 경기
+                .filter(dto -> !dto.teamB().contains("TBD"))
+                .map(dto -> Match.builder()
+                        .fetchId(dto.fetchId())
+                        .matchName(dto.matchName())
+                        .teamA(dto.teamA())
+                        .teamB(dto.teamB())
+                        .startTime(dto.startTime())
+                        .build()).forEach(matchRepository::save);
     }
 }

--- a/src/main/java/org/example/oddventure/domain/grid/dto/response/MatchFetchResponse.java
+++ b/src/main/java/org/example/oddventure/domain/grid/dto/response/MatchFetchResponse.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 
 @Builder
 public record MatchFetchResponse(
+        Long fetchId,
         String matchName,
         String teamA,
         String teamB,

--- a/src/main/java/org/example/oddventure/domain/grid/dto/response/MatchFetchResponse.java
+++ b/src/main/java/org/example/oddventure/domain/grid/dto/response/MatchFetchResponse.java
@@ -1,0 +1,13 @@
+package org.example.oddventure.domain.grid.dto.response;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+@Builder
+public record MatchFetchResponse(
+        String matchName,
+        String teamA,
+        String teamB,
+        LocalDateTime startTime
+) {
+}

--- a/src/main/java/org/example/oddventure/domain/grid/service/GridService.java
+++ b/src/main/java/org/example/oddventure/domain/grid/service/GridService.java
@@ -1,0 +1,121 @@
+package org.example.oddventure.domain.grid.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.example.oddventure.common.config.WebClientConfig;
+import org.example.oddventure.domain.grid.dto.response.MatchFetchResponse;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GridService {
+
+    private static final String GRID_CENTRAL_DATA_QUERY = """
+            query GetAllSeriesInNext24Hours($after: Cursor) {
+              allSeries(
+                first: 10
+                after: $after
+                filter:{
+                  titleId: "28" # CS2
+                  startTimeScheduled:{
+                    gte: "2025-10-24T15:00:07+02:00"
+                    lte: "2025-10-25T15:00:07+02:00"
+                  }
+                }
+                orderBy: StartTimeScheduled
+              ) {
+                totalCount,
+                pageInfo{
+                  hasPreviousPage
+                  hasNextPage
+                  startCursor
+                  endCursor
+                }
+                edges{
+                  cursor
+                  node{
+                    ...seriesFields
+                  }
+                }
+              }
+            }
+            fragment seriesFields on Series {
+              id
+              title {
+                nameShortened
+              }
+              tournament {
+                nameShortened
+              }
+              startTimeScheduled
+              format {
+                nameShortened
+              }
+              teams {
+                baseInfo {
+                  name
+                }
+              }
+            }
+            """;
+    private final WebClientConfig webClientConfig;
+    private final ObjectMapper objectMapper;
+
+    public List<MatchFetchResponse> fetchMatches() {
+        String cursor = null;
+        List<MatchFetchResponse> results = new ArrayList<>();
+
+        while (true) {
+            String request;
+            try {
+                request = objectMapper.writeValueAsString(
+                        Map.of("query", GRID_CENTRAL_DATA_QUERY,
+                                "variables", Map.of("after", cursor)
+                        )
+                );
+            } catch (JsonProcessingException e) {
+                return results;
+            }
+
+            JsonNode response = webClientConfig.gridCentralClient().post()
+                    .bodyValue(request)
+                    .retrieve()
+                    .bodyToMono(JsonNode.class)
+                    .onErrorReturn(null)
+                    .block();
+
+            if (response == null || response.path("data").isMissingNode()) {
+                return results;
+            }
+
+            JsonNode allSeries = response.path("data").path("allSeries");
+
+            for (JsonNode edge : allSeries.path("edges")) {
+                JsonNode node = edge.path("node");
+                String teamA = node.path("teams").get(0).path("baseInfo").path("name").asText();
+                String teamB = node.path("teams").get(1).path("baseInfo").path("name").asText();
+
+                results.add(MatchFetchResponse.builder()
+                        .matchName(node.path("tournament").path("nameShortened").asText())
+                        .teamA(teamA)
+                        .teamB(teamB)
+                        .startTime(LocalDateTime.parse(node.path("startTimeScheduled").asText()))
+                        .build());
+            }
+            boolean hasNext = allSeries.path("pageInfo").path("hasNextPage").asBoolean();
+            if (!hasNext) {
+                break;
+            }
+
+            cursor = allSeries.path("pageInfo").path("endCursor").asText();
+        }
+
+        return results;
+    }
+}

--- a/src/main/java/org/example/oddventure/domain/grid/service/GridService.java
+++ b/src/main/java/org/example/oddventure/domain/grid/service/GridService.java
@@ -98,10 +98,12 @@ public class GridService {
 
             for (JsonNode edge : allSeries.path("edges")) {
                 JsonNode node = edge.path("node");
+                Long fetchId = node.path("id").asLong();
                 String teamA = node.path("teams").get(0).path("baseInfo").path("name").asText();
                 String teamB = node.path("teams").get(1).path("baseInfo").path("name").asText();
 
                 results.add(MatchFetchResponse.builder()
+                        .fetchId(fetchId)
                         .matchName(node.path("tournament").path("nameShortened").asText())
                         .teamA(teamA)
                         .teamB(teamB)

--- a/src/main/java/org/example/oddventure/domain/grid/service/GridService.java
+++ b/src/main/java/org/example/oddventure/domain/grid/service/GridService.java
@@ -3,15 +3,21 @@ package org.example.oddventure.domain.grid.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
 import org.example.oddventure.common.config.WebClientConfig;
 import org.example.oddventure.domain.grid.dto.response.MatchFetchResponse;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 
+@Log4j2
 @Service
 @RequiredArgsConstructor
 public class GridService {
@@ -68,28 +74,31 @@ public class GridService {
     private final ObjectMapper objectMapper;
 
     public List<MatchFetchResponse> fetchMatches() {
-        String cursor = null;
         List<MatchFetchResponse> results = new ArrayList<>();
+        Map<String, Object> variables = new HashMap<>();
 
+        String cursor = null; // 페이지네이션 커서
         while (true) {
+            variables.put("after", cursor);
             String request;
             try {
                 request = objectMapper.writeValueAsString(
                         Map.of("query", GRID_CENTRAL_DATA_QUERY,
-                                "variables", Map.of("after", cursor)
+                                "variables", variables
                         )
                 );
+//                log.info("Fetching matches from GRID: {}", request);
             } catch (JsonProcessingException e) {
                 return results;
             }
 
             JsonNode response = webClientConfig.gridCentralClient().post()
+                    .contentType(MediaType.APPLICATION_JSON)
                     .bodyValue(request)
                     .retrieve()
                     .bodyToMono(JsonNode.class)
-                    .onErrorReturn(null)
                     .block();
-
+//            log.info("Got response from GRID central client: {}", response);
             if (response == null || response.path("data").isMissingNode()) {
                 return results;
             }
@@ -101,17 +110,19 @@ public class GridService {
                 Long fetchId = node.path("id").asLong();
                 String teamA = node.path("teams").get(0).path("baseInfo").path("name").asText();
                 String teamB = node.path("teams").get(1).path("baseInfo").path("name").asText();
+                LocalDateTime startTime = Instant.parse(node.path("startTimeScheduled").asText())
+                        .atZone(ZoneId.of("Asia/Seoul"))
+                        .toLocalDateTime();
 
                 results.add(MatchFetchResponse.builder()
                         .fetchId(fetchId)
                         .matchName(node.path("tournament").path("nameShortened").asText())
                         .teamA(teamA)
                         .teamB(teamB)
-                        .startTime(LocalDateTime.parse(node.path("startTimeScheduled").asText()))
+                        .startTime(startTime)
                         .build());
             }
-            boolean hasNext = allSeries.path("pageInfo").path("hasNextPage").asBoolean();
-            if (!hasNext) {
+            if (!allSeries.path("pageInfo").path("hasNextPage").asBoolean()) {
                 break;
             }
 

--- a/src/main/java/org/example/oddventure/domain/match/entity/Match.java
+++ b/src/main/java/org/example/oddventure/domain/match/entity/Match.java
@@ -61,7 +61,8 @@ public class Match extends BaseEntity {
     private Long viewCount = 0L;
 
     @Builder
-    public Match(String matchName, String teamA, String teamB, LocalDateTime startTime) {
+    public Match(Long fetchId, String matchName, String teamA, String teamB, LocalDateTime startTime) {
+        this.fetchId = fetchId;
         this.matchName = matchName;
         this.teamA = teamA;
         this.teamB = teamB;

--- a/src/main/java/org/example/oddventure/domain/match/entity/Match.java
+++ b/src/main/java/org/example/oddventure/domain/match/entity/Match.java
@@ -27,6 +27,8 @@ public class Match extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    private Long fetchId;
+
     @Column(nullable = false)
     private String matchName;
 

--- a/src/main/java/org/example/oddventure/domain/match/repository/MatchRepository.java
+++ b/src/main/java/org/example/oddventure/domain/match/repository/MatchRepository.java
@@ -1,7 +1,6 @@
 package org.example.oddventure.domain.match.repository;
 
 import jakarta.persistence.LockModeType;
-
 import java.util.List;
 import java.util.Optional;
 import org.example.oddventure.domain.match.entity.Match;
@@ -23,6 +22,9 @@ public interface MatchRepository extends JpaRepository<Match, Long>, MatchReposi
 
     @Query("select m.winner from Match m where m.winner is not null")
     List<String> findByWinnerIsNotNull();
+
     @Query("select m.loser from Match m where m.loser is not null")
     List<String> findByLoserIsNotNull();
+
+    boolean existsByFetchId(Long fetchId);
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -28,4 +28,9 @@ jwt:
   secret:
     key: ${jwt.secret.key}
 
-
+grid:
+  central-data:
+    base-url: ${grid.central.base.url}
+  live-data:
+    base-url: ${grid.live.base.url}
+  api-key: ${grid.api.key}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -33,3 +33,10 @@ spring:
 jwt:
   secret:
     key: "${SECRET_KEY}"
+
+grid:
+  central-data:
+    base-url: ${GRID_CENTRAL_BASE_URL}
+  live-data:
+    base-url: ${GRID_LIVE_BASE_URL}
+  api-key: ${GRID_API_KEY}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,6 +29,12 @@ spring:
         options:
           model: llama-3.3-70b-versatile
           temperature: 0.0
+  cloud:
+    aws:
+      region:
+        static: ap-northeast-2
+      credentials:
+        instance-profile: false
 
 jwt:
   secret:

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -32,3 +32,10 @@ spring:
 jwt:
   secret:
     key: dGVzdC1zZWNyZXQta2V5LWZvci10ZXN0aW5nLWp3dC10b2tlbi1nZW5lcmF0aW9uLW1pbmltdW0tMzItYnl0ZXM=
+
+grid:
+  central-data:
+    base-url: dummy
+  live-data:
+    base-url: dummy
+  api-key: dummy


### PR DESCRIPTION
## 📝 작업 내용
<!---- 변경 사항 및 관련 이슈 예시
- 컨트롤러 API 수정
- Entity 생성자 추가
- 등등
-->
- 매치 일정 연동 API입니다.
    - 현재 admin 도메인에서 수동으로 연동 가능합니다.
    - 이후 스케줄링 도입으로 자동 처리될 예정입니다.
- [배치 삽입 방식](https://www.notion.so/teamsparta/2982dc3ef5148037be0dffcb7beaac65)으로 리팩토링 예정입니다. 
- JsonNode -> 응답 reponse 리팩토링 예정입니다.
- 책임 분리를 위한 admin 패키지 내 domain별 패키지 분리로 리팩토링 예정입니다.
- 리팩토링 이후 테스트코드 추가 예정입니다.

<!---- 스크린샷 (선택) -->

## 🔗 연관된 이슈
- #58 
<!---- Related to: #(Isuue Number) -->

<!---- 리뷰 요구사항 (선택) -->

<!---- 현재 버그 (선택) -->

## ✅ PR 유형

- [x] 새로운 기능 추가
