### PR TITLE
fix: Hotkeywords DB 업데이트 메서드 수정

### DIFF
--- a/src/main/java/org/example/oddventure/common/entity/BaseEntity.java
+++ b/src/main/java/org/example/oddventure/common/entity/BaseEntity.java
@@ -25,7 +25,7 @@ public abstract class BaseEntity {
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
-    @Column(name = "is_deleted", nullable = false)
+    @Column(name = "is_deleted")
     private boolean deleted;
 
     public void delete() {

--- a/src/main/java/org/example/oddventure/domain/hotKeywords/service/HotKeywordsService.java
+++ b/src/main/java/org/example/oddventure/domain/hotKeywords/service/HotKeywordsService.java
@@ -3,6 +3,7 @@ package org.example.oddventure.domain.hotKeywords.service;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.example.oddventure.domain.hotKeywords.dto.HotKeywordsResponse;
+import org.example.oddventure.domain.hotKeywords.entity.HotKeywords;
 import org.example.oddventure.domain.hotKeywords.repository.HotKeywordsRepository;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
@@ -35,5 +36,12 @@ public class HotKeywordsService {
                 hotKeywordsRepository.increaseSearchCountByValue(keyword, score);
             }
         }
+    }
+
+    public void incrementSearchScore(String keyword) {
+        if (hotKeywordsRepository.findByKeyword(keyword) == null) {
+            hotKeywordsRepository.save(HotKeywords.of(keyword)); //검색 키워드 저장
+        }
+        redisTemplate.opsForZSet().incrementScore(HOT_KEYWORDS_KEY, keyword, 1);
     }
 }

--- a/src/main/java/org/example/oddventure/domain/match/service/MatchService.java
+++ b/src/main/java/org/example/oddventure/domain/match/service/MatchService.java
@@ -1,6 +1,7 @@
 package org.example.oddventure.domain.match.service;
 
 import lombok.RequiredArgsConstructor;
+import org.example.oddventure.domain.hotKeywords.service.HotKeywordsService;
 import org.example.oddventure.domain.match.dto.projection.MatchProjection;
 import org.example.oddventure.domain.match.dto.request.MatchSearchCondition;
 import org.example.oddventure.domain.match.dto.response.MatchResponse;
@@ -19,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class MatchService {
 
     private final MatchRepository matchRepository;
+    private final HotKeywordsService hotKeywordsService;
 
     @Transactional(readOnly = true)
     public Page<MatchResponse> getMatches(Pageable pageable) {
@@ -39,9 +41,12 @@ public class MatchService {
         return MatchResponse.from(match);
     }
 
-    @Transactional(readOnly = true)
+    @Transactional
     public Page<MatchResponse> searchMatches(MatchSearchCondition condition, Pageable pageable) {
         Page<MatchProjection> projections = matchRepository.searchByCondition(condition, pageable);
+
+        hotKeywordsService.incrementSearchScore(condition.keyword());
+
         return projections.map(MatchResponse::of);
     }
 
@@ -53,7 +58,7 @@ public class MatchService {
         if (match.getStatus().equals(MatchStatus.FINISHED)) {
             throw new MatchException(MatchErrorCode.MATCH_FINISHED);
         }
-        
+
         match.finishMatch(winner, looser);
 
         return match;

--- a/src/test/java/org/example/oddventure/domain/match/unit/MatchServiceTest.java
+++ b/src/test/java/org/example/oddventure/domain/match/unit/MatchServiceTest.java
@@ -2,11 +2,13 @@ package org.example.oddventure.domain.match.unit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import org.example.oddventure.domain.hotKeywords.service.HotKeywordsService;
 import org.example.oddventure.domain.match.dto.projection.MatchProjection;
 import org.example.oddventure.domain.match.dto.request.MatchSearchCondition;
 import org.example.oddventure.domain.match.dto.response.MatchResponse;
@@ -35,6 +37,9 @@ class MatchServiceTest {
 
     @Mock
     private MatchRepository matchRepository;
+
+    @Mock
+    private HotKeywordsService hotKeywordsService;
 
     @Test
     @DisplayName("경기 목록 조회 성공")
@@ -148,6 +153,7 @@ class MatchServiceTest {
         MatchProjection response2 = MatchProjection.from(match2);
         Page<MatchProjection> matches = new PageImpl<>(List.of(response1, response2), pageable, 2);
 
+        doNothing().when(hotKeywordsService).incrementSearchScore(condition.keyword());
         when(matchRepository.searchByCondition(condition, pageable)).thenReturn(matches);
 
         // when


### PR DESCRIPTION
## 📝 작업 내용
<!---- 변경 사항 및 관련 이슈 예시
- 컨트롤러 API 수정
- Entity 생성자 추가
- 등등
-->
- 매치 인기검색어 조회 기능 중 DB 업데이트가 제대로 되지 않는 에러가 발생하였습니다.
- 에러 중 일부를 수정하였습니다.
- deleted_at 필드를 nullable로 수정하였습니다.

<!---- 스크린샷 (선택) -->

## 🔗 연관된 이슈
<!---- Related to: #(Isuue Number) -->

<!---- 리뷰 요구사항 (선택) -->

<!---- 현재 버그 (선택) -->

## ✅ PR 유형

- [x] 버그 수정
