### PR TITLE
feat: 동시성 제어 및 캐싱 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,6 +92,9 @@ dependencies {
     //prometheus
     implementation 'io.micrometer:micrometer-registry-prometheus'
 
+    // redisson
+    implementation 'org.redisson:redisson-spring-boot-starter:3.52.0'
+
 }
 
 dependencyManagement {

--- a/docker-compose-k6-test.yml
+++ b/docker-compose-k6-test.yml
@@ -67,6 +67,20 @@ services:
     networks:
       - oddventure-network
 
+  k6-cache-comparison:
+    image: grafana/k6:latest
+    container_name: oddventure-k6-cache-comparison
+    profiles:
+      - performance-test
+    volumes:
+      - ./k6/scripts:/scripts
+      - ./k6/results:/results
+    environment:
+      - API_URL=http://host.docker.internal:8080
+    command: run --out json=/results/cache-comparison-result.json --summary-export=/results/cache-comparison-summary.json /scripts/scenario-cache-comparison.js
+    networks:
+      - oddventure-network
+
 # 네트워크 정의
 networks:
   oddventure-network:

--- a/k6/scripts/scenario-cache-comparison.js
+++ b/k6/scripts/scenario-cache-comparison.js
@@ -134,7 +134,7 @@ export function setup() {
     console.log(`테스트 대상 API: ${BASE_URL}`);
     console.log(`종료된 경기 수: ${FINISHED_MATCH_IDS.length}개`);
     console.log('');
-    console.log('📌 테스트 단계:');
+    console.log('테스트 단계:');
     console.log('1. 워밍업 (30초): 캐시 채우기');
     console.log('2. 부하 테스트 (5분): 캐시 효과 측정');
     console.log('');
@@ -149,7 +149,7 @@ export function teardown(data) {
     console.log(`시작 시간: ${data.startTime}`);
     console.log(`종료 시간: ${new Date().toISOString()}`);
     console.log('');
-    console.log('📊 결과 요약:');
+    console.log('결과 요약:');
     console.log('- Grafana 대시보드에서 상세 메트릭 확인');
     console.log('- 캐시 적용 전후 응답 시간 비교');
     console.log('- DB 커넥션 풀 사용량 비교');

--- a/k6/scripts/scenario-cache-comparison.js
+++ b/k6/scripts/scenario-cache-comparison.js
@@ -1,0 +1,165 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Rate, Trend, Counter } from 'k6/metrics';
+import { htmlReport } from "https://raw.githubusercontent.com/benc-uk/k6-reporter/main/dist/bundle.js";
+
+// 커스텀 메트릭 정의
+const errorRate = new Rate('errors');
+const cacheHitRate = new Rate('cache_hits'); // 캐시 히트율 추정
+const responseTime = new Trend('match_detail_response_time');
+const dbAccessCount = new Counter('db_access_count'); // DB 접근 횟수 추정
+
+// 테스트 설정
+export const options = {
+    scenarios: {
+        // 시나리오 1: 워밍업 (캐시 채우기)
+        warmup: {
+            executor: 'constant-vus',
+            vus: 5,
+            duration: '30s',
+            startTime: '0s',
+            tags: { phase: 'warmup' },
+        },
+        // 시나리오 2: 실제 부하 테스트 (캐시 효과 측정)
+        load_test: {
+            executor: 'ramping-vus',
+            startVUs: 10,
+            stages: [
+                { duration: '30s', target: 10 },  // 10명 유지
+                { duration: '1m', target: 50 },   // 50명으로 증가
+                { duration: '1m', target: 50 },   // 50명 유지
+                { duration: '1m', target: 100 },  // 100명으로 증가
+                { duration: '1m', target: 100 },  // 100명 유지
+                { duration: '30s', target: 0 },   // 0명으로 감소
+            ],
+            startTime: '30s', // 워밍업 후 시작
+            tags: { phase: 'load_test' },
+        },
+    },
+
+    thresholds: {
+        // 응답 시간 임계값 (캐싱 적용 시 크게 개선되어야 함)
+        'match_detail_response_time': [
+            'p(50)<100',   // 중앙값 100ms 미만
+            'p(95)<300',   // 95% 300ms 미만
+            'p(99)<500',   // 99% 500ms 미만
+            'max<2000'     // 최대 2초 미만
+        ],
+
+        // 에러율 임계값
+        'errors': ['rate<0.01'], // 1% 미만
+
+        // HTTP 실패율
+        'http_req_failed': ['rate<0.01'],
+    },
+};
+
+const BASE_URL = __ENV.API_URL || 'http://host.docker.internal:8080';
+const MATCH_DETAIL_ENDPOINT = `${BASE_URL}/api/v1/matches`;
+const FINISHED_MATCH_IDS = [1, 2, 3, 4, 5];
+
+// 메인 테스트 함수
+export default function () {
+    // 종료된 경기 중 랜덤 선택 (캐시 히트율을 높이기 위해)
+    const matchId = FINISHED_MATCH_IDS[Math.floor(Math.random() * FINISHED_MATCH_IDS.length)];
+    const url = `${MATCH_DETAIL_ENDPOINT}/${matchId}`;
+
+    const params = {
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        tags: {
+            name: 'MatchDetail',
+            match_id: matchId.toString(),
+        },
+    };
+
+    const startTime = new Date();
+    const response = http.get(url, params);
+    const endTime = new Date();
+    const duration = endTime - startTime;
+
+    // 응답 검증
+    const checkRes = check(response, {
+        'status is 200': (r) => r.status === 200,
+        'has data': (r) => {
+            try {
+                const body = JSON.parse(r.body);
+                return body.data !== undefined && body.data !== null;
+            } catch (e) {
+                return false;
+            }
+        },
+        'match status is FINISHED': (r) => {
+            try {
+                const body = JSON.parse(r.body);
+                return body.data.status === 'FINISHED';
+            } catch (e) {
+                return false;
+            }
+        },
+        'response time < 500ms': (r) => r.timings.duration < 500,
+    });
+
+    // 메트릭 기록
+    errorRate.add(!checkRes);
+    responseTime.add(duration);
+
+    // 캐시 히트 추정 (응답 시간이 빠르면 캐시 히트로 간주)
+    // Redis 캐시 히트 시 일반적으로 10ms 미만
+    const isCacheHit = duration < 50;
+    cacheHitRate.add(isCacheHit ? 1 : 0);
+
+    if (!isCacheHit) {
+        dbAccessCount.add(1);
+    }
+
+    // 응답 시간별 로깅
+    if (__ITER % 100 === 0) { // 100번째 요청마다 로그
+        console.log(`[Iter ${__ITER}] matchId: ${matchId}, duration: ${duration}ms, cacheHit: ${isCacheHit}`);
+    }
+
+    // 느린 쿼리 감지
+    if (duration > 500) {
+        console.log(`느린 응답: ${duration}ms, matchId: ${matchId}`);
+    }
+
+    // 사용자 행동 시뮬레이션 (1~3초 대기)
+    sleep(Math.random() * 2 + 1);
+}
+
+// 테스트 시작 시 실행
+export function setup() {
+    console.log('=== 캐싱 성능 비교 테스트 시작 ===');
+    console.log(`테스트 대상 API: ${BASE_URL}`);
+    console.log(`종료된 경기 수: ${FINISHED_MATCH_IDS.length}개`);
+    console.log('');
+    console.log('📌 테스트 단계:');
+    console.log('1. 워밍업 (30초): 캐시 채우기');
+    console.log('2. 부하 테스트 (6분 30초): 캐시 효과 측정');
+    console.log('');
+
+    return { startTime: new Date().toISOString() };
+}
+
+// 테스트 종료 시 실행
+export function teardown(data) {
+    console.log('');
+    console.log('=== 테스트 완료 ===');
+    console.log(`시작 시간: ${data.startTime}`);
+    console.log(`종료 시간: ${new Date().toISOString()}`);
+    console.log('');
+    console.log('📊 결과 요약:');
+    console.log('- Grafana 대시보드에서 상세 메트릭 확인');
+    console.log('- 캐시 적용 전후 응답 시간 비교');
+    console.log('- DB 커넥션 풀 사용량 비교');
+    console.log('- JVM 메모리 사용량 비교');
+}
+
+// HTML 리포트 생성
+export function handleSummary(data) {
+    return {
+        "k6/results/cache-comparison-summary.html": htmlReport(data),
+        "k6/results/cache-comparison-summary.json": JSON.stringify(data),
+    };
+}

--- a/k6/scripts/scenario-cache-comparison.js
+++ b/k6/scripts/scenario-cache-comparison.js
@@ -1,13 +1,12 @@
 import http from 'k6/http';
 import { check, sleep } from 'k6';
 import { Rate, Trend, Counter } from 'k6/metrics';
-import { htmlReport } from "https://raw.githubusercontent.com/benc-uk/k6-reporter/main/dist/bundle.js";
 
 // 커스텀 메트릭 정의
 const errorRate = new Rate('errors');
-const cacheHitRate = new Rate('cache_hits'); // 캐시 히트율 추정
+const cacheHitRate = new Rate('cache_hits');
 const responseTime = new Trend('match_detail_response_time');
-const dbAccessCount = new Counter('db_access_count'); // DB 접근 횟수 추정
+const dbAccessCount = new Counter('db_access_count');
 
 // 테스트 설정
 export const options = {
@@ -32,7 +31,7 @@ export const options = {
                 { duration: '1m', target: 100 },  // 100명 유지
                 { duration: '30s', target: 0 },   // 0명으로 감소
             ],
-            startTime: '30s', // 워밍업 후 시작
+            startTime: '30s',
             tags: { phase: 'load_test' },
         },
     },
@@ -54,9 +53,15 @@ export const options = {
     },
 };
 
+// 환경 변수에서 API URL 가져오기
 const BASE_URL = __ENV.API_URL || 'http://host.docker.internal:8080';
 const MATCH_DETAIL_ENDPOINT = `${BASE_URL}/api/v1/matches`;
-const FINISHED_MATCH_IDS = [1, 2, 3, 4, 5];
+
+// 테스트할 경기 ID 목록 (FINISHED 상태의 경기들)
+// 실제 DB에 있는 종료된 경기 ID로 변경해야 함
+const FINISHED_MATCH_IDS = [
+    1, 2, 3, 4, 5
+];
 
 // 메인 테스트 함수
 export default function () {
@@ -106,7 +111,7 @@ export default function () {
     responseTime.add(duration);
 
     // 캐시 히트 추정 (응답 시간이 빠르면 캐시 히트로 간주)
-    // Redis 캐시 히트 시 일반적으로 10ms 미만
+    // Redis 캐시 히트 시 일반적으로 10~50ms
     const isCacheHit = duration < 50;
     cacheHitRate.add(isCacheHit ? 1 : 0);
 
@@ -114,8 +119,8 @@ export default function () {
         dbAccessCount.add(1);
     }
 
-    // 응답 시간별 로깅
-    if (__ITER % 100 === 0) { // 100번째 요청마다 로그
+    // 응답 시간별 로깅 (100번째 요청마다)
+    if (__ITER % 100 === 0) {
         console.log(`[Iter ${__ITER}] matchId: ${matchId}, duration: ${duration}ms, cacheHit: ${isCacheHit}`);
     }
 
@@ -137,6 +142,13 @@ export function setup() {
     console.log('테스트 단계:');
     console.log('1. 워밍업 (30초): 캐시 채우기');
     console.log('2. 부하 테스트 (5분): 캐시 효과 측정');
+    console.log('   - 10 VUs → 50 VUs → 100 VUs 단계별 증가');
+    console.log('');
+    console.log('측정 항목:');
+    console.log('- 응답 시간 (p50, p95, p99)');
+    console.log('- 캐시 히트율');
+    console.log('- DB 접근 횟수');
+    console.log('- 에러율');
     console.log('');
 
     return { startTime: new Date().toISOString() };
@@ -154,12 +166,8 @@ export function teardown(data) {
     console.log('- 캐시 적용 전후 응답 시간 비교');
     console.log('- DB 커넥션 풀 사용량 비교');
     console.log('- JVM 메모리 사용량 비교');
-}
-
-// HTML 리포트 생성
-export function handleSummary(data) {
-    return {
-        "k6/results/cache-comparison-summary.html": htmlReport(data),
-        "k6/results/cache-comparison-summary.json": JSON.stringify(data),
-    };
+    console.log('');
+    console.log('결과 파일 위치:');
+    console.log('- JSON: k6/results/scenario-cache-comparison-{VUS}vus-result.json');
+    console.log('- Summary: k6/results/scenario-cache-comparison-{VUS}vus-summary.json');
 }

--- a/k6/scripts/scenario-cache-comparison.js
+++ b/k6/scripts/scenario-cache-comparison.js
@@ -136,7 +136,7 @@ export function setup() {
     console.log('');
     console.log('📌 테스트 단계:');
     console.log('1. 워밍업 (30초): 캐시 채우기');
-    console.log('2. 부하 테스트 (6분 30초): 캐시 효과 측정');
+    console.log('2. 부하 테스트 (5분): 캐시 효과 측정');
     console.log('');
 
     return { startTime: new Date().toISOString() };

--- a/src/main/java/org/example/oddventure/common/config/CachingConfig.java
+++ b/src/main/java/org/example/oddventure/common/config/CachingConfig.java
@@ -1,5 +1,6 @@
 package org.example.oddventure.common.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -9,7 +10,6 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
-
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
@@ -18,9 +18,15 @@ import java.util.Map;
 @EnableCaching
 public class CachingConfig {
 
+    // RedisConfig에서 생성한 공용 ObjectMapper를 주입
+
     @Bean
-    public RedisCacheManager redisCacheManager(RedisConnectionFactory cf) {
-        var valueSerializer = new GenericJackson2JsonRedisSerializer(); // DTO 캐싱
+    public RedisCacheManager redisCacheManager(RedisConnectionFactory cf,
+                                               ObjectMapper redisObjectMapper) { // ObjectMapper 주입
+
+        // 주입받은 ObjectMapper로 Serializer 생성
+        var valueSerializer = new GenericJackson2JsonRedisSerializer(redisObjectMapper);
+
         var base = RedisCacheConfiguration.defaultCacheConfig()
                 .disableCachingNullValues()
                 .serializeKeysWith(

--- a/src/main/java/org/example/oddventure/common/config/CachingConfig.java
+++ b/src/main/java/org/example/oddventure/common/config/CachingConfig.java
@@ -30,6 +30,9 @@ public class CachingConfig {
 
         Map<String, RedisCacheConfiguration> perCache = new HashMap<>();
         perCache.put("match:ranking", base.entryTtl(Duration.ofMinutes(30)));
+        perCache.put("matchDetails", base.entryTtl(Duration.ofMinutes(30)));
+        perCache.put("teams", base.entryTtl(Duration.ofMinutes(30)));
+        perCache.put("teamDetail", base.entryTtl(Duration.ofMinutes(30)));
 
         return RedisCacheManager.builder(cf)
                 .cacheDefaults(base)

--- a/src/main/java/org/example/oddventure/common/config/RedisConfig.java
+++ b/src/main/java/org/example/oddventure/common/config/RedisConfig.java
@@ -1,12 +1,23 @@
 package org.example.oddventure.common.config;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.util.List;
 import org.example.oddventure.domain.event.RedisSubscriber;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -32,16 +43,39 @@ public class RedisConfig {
         return new LettuceConnectionFactory(host, port);
     }
 
-    @Bean
-    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
-        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
-        redisTemplate.setConnectionFactory(redisConnectionFactory);
 
+    // 캐시와 RedisTemplate이 공용으로 사용할 ObjectMapper 빈을 생성
+    @Bean
+    public ObjectMapper redisObjectMapper() {
         ObjectMapper objectMapper = new ObjectMapper();
+
+        // 1. LocalDateTime 직렬화 모듈
         objectMapper.registerModule(new JavaTimeModule());
         objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
 
-        GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(objectMapper);
+        // 2. Page 객체 역직렬화 모듈 (PageImpl, PageRequest, Sort)
+        objectMapper.registerModule(pageModule());
+
+        // 3. record 클래스(final)를 포함한 모든 객체에 타입 정보를 추가
+        objectMapper.activateDefaultTyping(
+                LaissezFaireSubTypeValidator.instance,
+                ObjectMapper.DefaultTyping.EVERYTHING, // NON_FINAL에서 변경
+                JsonTypeInfo.As.PROPERTY
+        );
+
+        return objectMapper;
+    }
+
+
+    // 공용 ObjectMapper를 주입받아 RedisTemplate을 생성
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory,
+                                                       ObjectMapper redisObjectMapper) { // ObjectMapper 주입
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory);
+
+        // 주입받은 ObjectMapper로 Serializer 생성
+        GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(redisObjectMapper);
 
         redisTemplate.setKeySerializer(new StringRedisSerializer());
         redisTemplate.setValueSerializer(serializer);
@@ -51,7 +85,8 @@ public class RedisConfig {
         return redisTemplate;
     }
 
-    // Redis Pub/Sub 메시지 브로커 설정
+    // --- Redis Pub/Sub 설정 ---
+
     @Bean
     public RedisMessageListenerContainer redisMessageListenerContainer(
             RedisConnectionFactory connectionFactory,
@@ -60,11 +95,8 @@ public class RedisConfig {
     ) {
         RedisMessageListenerContainer container = new RedisMessageListenerContainer();
         container.setConnectionFactory(connectionFactory);
-
-        // Pub/Sub 채널 구독 설정
         container.addMessageListener(oddsListenerAdapter, new PatternTopic("match:*:odds"));
         container.addMessageListener(infoListenerAdapter, new PatternTopic("match:*:info"));
-
         return container;
     }
 
@@ -76,5 +108,49 @@ public class RedisConfig {
     @Bean
     public MessageListenerAdapter infoListenerAdapter(RedisSubscriber subscriber) {
         return new MessageListenerAdapter(subscriber);
+    }
+
+    // --- Page/Sort Mixin Helper ---
+
+
+    // PageImpl, PageRequest, Sort 역직렬화를 위한 Jackson Mixin 모듈
+    private Module pageModule() {
+        SimpleModule module = new SimpleModule();
+        module.setMixInAnnotation(PageImpl.class, PageImplMixin.class);
+        module.setMixInAnnotation(PageRequest.class, PageRequestMixin.class);
+        module.setMixInAnnotation(Sort.class, SortMixin.class);
+        return module;
+    }
+
+
+    // PageImpl 역직렬화용 Mixin
+    private abstract static class PageImplMixin<T> {
+        @JsonCreator
+        PageImplMixin(
+                @JsonProperty("content") List<T> content,
+                @JsonProperty("pageable") Pageable pageable,
+                @JsonProperty("totalElements") long totalElements) {}
+    }
+
+    // PageRequest 역직렬화용 Mixin
+    private abstract static class PageRequestMixin {
+        @JsonCreator
+        static PageRequest of(
+                @JsonProperty("page") int page,
+                @JsonProperty("size") int size,
+                @JsonProperty("sort") Sort sort) {
+            return PageRequest.of(page, size, sort);
+        }
+    }
+
+    // Sort 역직렬화용 Mixin (unsorted 처리 포함)
+    private abstract static class SortMixin {
+        @JsonCreator
+        static Sort by(@JsonProperty("orders") List<Sort.Order> orders) {
+            if (orders == null || orders.isEmpty()) {
+                return Sort.unsorted();
+            }
+            return Sort.by(orders);
+        }
     }
 }

--- a/src/main/java/org/example/oddventure/domain/bet/exception/BetErrorCode.java
+++ b/src/main/java/org/example/oddventure/domain/bet/exception/BetErrorCode.java
@@ -15,7 +15,8 @@ public enum BetErrorCode implements ErrorCode {
     MATCH_NOT_CANCELABLE(HttpStatus.BAD_REQUEST, "취소가 불가능한 매치입니다."),
     ODDS_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 베팅 항목입니다."),
     BET_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 베팅 내역입니다."),
-    PERMISSION_DENIED(HttpStatus.FORBIDDEN, "베팅을 취소할 권한이 없습니다.");
+    PERMISSION_DENIED(HttpStatus.FORBIDDEN, "베팅을 취소할 권한이 없습니다."),
+    BET_LOCK_FAILED(HttpStatus.CONFLICT, "다른 요청을 처리 중입니다. 잠시 후 다시 시도해주세요.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/org/example/oddventure/domain/bet/service/BetService.java
+++ b/src/main/java/org/example/oddventure/domain/bet/service/BetService.java
@@ -39,7 +39,8 @@ public class BetService {
 
     @Transactional
     public BetCreateResponse createBet(Long userId, BetCreateRequest request) {
-        User user = findUserById(userId);
+        User user = userRepository.findByIdForUpdate(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
 
         BigDecimal betAmount = BigDecimal.valueOf(request.betAmount());
 
@@ -99,7 +100,8 @@ public class BetService {
         bet.delete();
 
         // 환불
-        User user = bet.getUser();
+        User user = userRepository.findByIdForUpdate(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
         user.plusPoint(bet.getBetAmount());
 
         // 총 베팅 금액 되돌리기

--- a/src/main/java/org/example/oddventure/domain/bet/service/BetService.java
+++ b/src/main/java/org/example/oddventure/domain/bet/service/BetService.java
@@ -75,10 +75,8 @@ public class BetService {
             Thread.currentThread().interrupt();
             throw new BetException(CommonErrorCode.INTERNAL_SERVER_ERROR);
         } finally {
-            // 6. 락 해제 (userLock, matchLock 모두 해제됨)
-            if (multiLock.isLocked() && multiLock.isHeldByCurrentThread()) {
-                multiLock.unlock();
-            }
+            // 6. 락 해제
+            multiLock.unlock();
         }
     }
 
@@ -121,9 +119,7 @@ public class BetService {
             throw new BetException(CommonErrorCode.INTERNAL_SERVER_ERROR);
         } finally {
             // 4. 락 해제
-            if (multiLock.isLocked() && multiLock.isHeldByCurrentThread()) {
-                multiLock.unlock();
-            }
+            multiLock.unlock();
         }
     }
 

--- a/src/main/java/org/example/oddventure/domain/bet/service/BetService.java
+++ b/src/main/java/org/example/oddventure/domain/bet/service/BetService.java
@@ -1,79 +1,78 @@
 package org.example.oddventure.domain.bet.service;
 
-import java.math.BigDecimal;
-import java.math.RoundingMode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import java.util.concurrent.TimeUnit;
+import org.example.oddventure.common.exception.CommonErrorCode;
 import org.example.oddventure.domain.bet.dto.request.BetCreateRequest;
 import org.example.oddventure.domain.bet.dto.response.BetCreateResponse;
 import org.example.oddventure.domain.bet.dto.response.BetDeleteResponse;
 import org.example.oddventure.domain.bet.dto.response.BetResponse;
 import org.example.oddventure.domain.bet.entity.Bet;
-import org.example.oddventure.domain.bet.enums.SelectedTeam;
 import org.example.oddventure.domain.bet.exception.BetErrorCode;
 import org.example.oddventure.domain.bet.exception.BetException;
 import org.example.oddventure.domain.bet.repository.BetRepository;
+import org.example.oddventure.domain.bet.service.BetTransactionService.CreateBetData;
+import org.example.oddventure.domain.bet.service.BetTransactionService.DeleteBetData;
 import org.example.oddventure.domain.event.RedisPublisher;
 import org.example.oddventure.domain.match.dto.event.MatchOddsUpdateDto;
-import org.example.oddventure.domain.match.entity.Match;
-import org.example.oddventure.domain.match.enums.MatchStatus;
-import org.example.oddventure.domain.match.exception.MatchErrorCode;
-import org.example.oddventure.domain.match.exception.MatchException;
-import org.example.oddventure.domain.match.repository.MatchRepository;
-import org.example.oddventure.domain.user.entity.User;
-import org.example.oddventure.domain.user.exception.UserErrorCode;
-import org.example.oddventure.domain.user.exception.UserException;
-import org.example.oddventure.domain.user.repository.UserRepository;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class BetService {
 
     private final BetRepository betRepository;
-    private final UserRepository userRepository;
-    private final MatchRepository matchRepository;
     private final RedisPublisher redisPublisher;
+    private final RedissonClient redissonClient;
+    private final BetTransactionService betTransactionService;
+    private static final String USER_POINT_LOCK_PREFIX = "LOCK:USER_POINT:";
+    private static final String MATCH_LOCK_PREFIX = "LOCK:MATCH:";
 
-    @Transactional
     public BetCreateResponse createBet(Long userId, BetCreateRequest request) {
-        User user = userRepository.findByIdForUpdate(userId)
-                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
 
-        BigDecimal betAmount = BigDecimal.valueOf(request.betAmount());
+        // 1. 락 2개 정의 (User, Match)
+        String userLockKey = USER_POINT_LOCK_PREFIX + userId;
+        String matchLockKey = MATCH_LOCK_PREFIX + request.matchId();
 
-        // 잔액 부족
-        if (user.getPoint().compareTo(betAmount) < 0) {
-            throw new BetException(BetErrorCode.NOT_ENOUGH_POINTS);
+        RLock userLock = redissonClient.getLock(userLockKey);
+        RLock matchLock = redissonClient.getLock(matchLockKey);
+
+        // 2. MultiLock으로 두 락을 묶음
+        RLock multiLock = redissonClient.getMultiLock(userLock, matchLock);
+
+        try {
+            // 3. 락 획득 시도 (데드락 방지를 위해 순서대로 락을 잡음)
+            boolean isLocked = multiLock.tryLock(10, 5, TimeUnit.SECONDS);
+
+            if (!isLocked) {
+                log.warn("베팅 락 획득 실패. userId: {}, matchId: {}", userId, request.matchId());
+                throw new BetException(BetErrorCode.BET_LOCK_FAILED);
+            }
+
+            // 4. 락 획득 성공 시, 분리된 트랜잭션 메서드 호출
+            CreateBetData data = betTransactionService.createBetInternal(userId, request);
+
+            // 5. 트랜잭션 커밋 성공 후, Redis 이벤트 발행
+            MatchOddsUpdateDto dto = new MatchOddsUpdateDto(data.bet().getMatch().getId(), data.selectedTeamName(), data.odds());
+            redisPublisher.publish("match:" + dto.matchId() + ":odds", dto);
+
+            return BetCreateResponse.of(data.bet(), data.selectedTeamName(), data.userPointAfter());
+
+        } catch (InterruptedException e) {
+            log.error("베팅 락 대기 중 인터럽트 발생", e);
+            Thread.currentThread().interrupt();
+            throw new BetException(CommonErrorCode.INTERNAL_SERVER_ERROR);
+        } finally {
+            // 6. 락 해제 (userLock, matchLock 모두 해제됨)
+            multiLock.unlock();
         }
-
-        Match match = matchRepository.findByIdForUpdate(request.matchId())
-                .orElseThrow(() -> new MatchException(MatchErrorCode.MATCH_NOT_FOUND));
-
-        // 베팅 가능 여부 검증
-        validateBettable(match);
-
-        // 유저 포인트 차감
-        user.minusPoint(betAmount);
-
-        // 배당률 계산
-        BigDecimal odds = calculateOdds(match, request.selectedTeam());
-
-        // 베팅 금액 저장
-        updateTotalAmount(match, betAmount, request.selectedTeam());
-
-        Bet bet = request.toEntity(user, match, odds);
-        betRepository.save(bet);
-
-        String selectedTeamName = selectedTeamName(match, request.selectedTeam());
-
-        // 배당률 변경 시 Redis Pub/Sub으로 실시간 알림 전송
-        MatchOddsUpdateDto dto = new MatchOddsUpdateDto(match.getId(), selectedTeamName, odds);
-        redisPublisher.publish("match:" + dto.matchId() + ":odds", dto);
-
-        return BetCreateResponse.of(bet, selectedTeamName, user.getPoint());
     }
 
     @Transactional(readOnly = true)
@@ -82,99 +81,43 @@ public class BetService {
         return bets.map(BetResponse::from);
     }
 
-    @Transactional
     public BetDeleteResponse deleteBet(Long userId, Long betId) {
-        Bet bet = betRepository.findByIdForDelete(betId)
+
+        // 베팅 취소는 락 대상이 많으므로 락 획득 전 Bet 정보가 필요
+        // 단, 이 조회는 락을 잡지 않으므로 데이터가 정확하지 않을 수 있음
+        Bet preFetchedBet = betRepository.findById(betId)
                 .orElseThrow(() -> new BetException(BetErrorCode.BET_NOT_FOUND));
 
-        // 본인 베팅 확인
-        if (!bet.getUser().getId().equals(userId)) {
-            throw new BetException(BetErrorCode.PERMISSION_DENIED);
-        }
+        // 1. 락 2개 정의 (User, Match)
+        String userLockKey = USER_POINT_LOCK_PREFIX + userId;
+        String matchLockKey = MATCH_LOCK_PREFIX + preFetchedBet.getMatch().getId();
 
-        // 취소 가능 여부 확인
-        Match match = matchRepository.findByIdForUpdate(bet.getMatch().getId())
-                .orElseThrow(() -> new MatchException(MatchErrorCode.MATCH_NOT_FOUND));
-        validateCancelable(match.getStatus());
+        RLock userLock = redissonClient.getLock(userLockKey);
+        RLock matchLock = redissonClient.getLock(matchLockKey);
 
-        bet.delete();
+        RLock multiLock = redissonClient.getMultiLock(userLock, matchLock);
 
-        // 환불
-        User user = userRepository.findByIdForUpdate(userId)
-                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
-        user.plusPoint(bet.getBetAmount());
+        try {
+            // 2. 락 획득
+            boolean isLocked = multiLock.tryLock(10, 5, TimeUnit.SECONDS);
+            if (!isLocked) {
+                log.warn("베팅 취소 락 획득 실패. userId: {}, betId: {}", userId, betId);
+                throw new BetException(BetErrorCode.BET_LOCK_FAILED);
+            }
 
-        // 총 베팅 금액 되돌리기
-        refundTotalAmount(match, bet.getBetAmount(), bet.getSelectedTeam());
+            // 3. 락 획득 후 트랜잭션 호출
+            // (트랜잭션 내부에서 데이터를 다시 조회하므로 정합성 보장)
+            DeleteBetData data = betTransactionService.deleteBetInternal(userId, betId);
 
-        return BetDeleteResponse.of(bet, user);
-    }
+            return BetDeleteResponse.of(data.bet(), data.user());
 
-    private User findUserById(Long userId) {
-        return userRepository.findById(userId)
-                .orElseThrow(() -> new UserException(UserErrorCode.INVALID_USER_ID));
-    }
-
-    private void validateBettable(Match match) {
-        if (match.isDeleted()) {
-            throw new BetException(BetErrorCode.MATCH_NOT_EXIST);
-        }
-
-        if (!match.getStatus().equals(MatchStatus.SCHEDULED)) {
-            throw new BetException(BetErrorCode.MATCH_NOT_BETTABLE);
-        }
-    }
-
-    private void validateCancelable(MatchStatus status) {
-        if (!status.equals(MatchStatus.SCHEDULED)) {
-            throw new BetException(BetErrorCode.MATCH_NOT_CANCELABLE);
-        }
-    }
-
-    private void updateTotalAmount(Match match, BigDecimal amount, SelectedTeam selectedTeam) {
-        if (selectedTeam.equals(SelectedTeam.Team_A)) {
-            match.plusTeamA(amount);
-        } else if (selectedTeam.equals(SelectedTeam.Team_B)) {
-            match.plusTeamB(amount);
-        }
-    }
-
-    private void refundTotalAmount(Match match, BigDecimal amount, SelectedTeam selectedTeam) {
-        if (selectedTeam.equals(SelectedTeam.Team_A)) {
-            match.minusTeamA(amount);
-        } else if (selectedTeam.equals(SelectedTeam.Team_B)) {
-            match.minusTeamB(amount);
-        }
-    }
-
-    /***
-     * 승 배당률 = 0.9 / 승 금액 비율
-     * 0.9 = 1 - 0.1(수수료)
-     * 승 금액 비율 = 승 총 베팅 금액 / 전체 베팅 금액(승 + 패)
-     * 처음 배당률 지정 로직과
-     * 이후 배당률 조정 로직이 필요하다. (이는 베팅 생성시 호출된다.)
-     * 배당률 조정 로직 구현 시, 유저 비율도 고려하는 가중 조합형 배당률로 구현하는 것이 필요해 보인다.
-     */
-    private BigDecimal calculateOdds(Match match, SelectedTeam selectedTeam) {
-        BigDecimal total = match.getTotalAmountA().add(match.getTotalAmountB());
-        System.out.println("total: " + total);
-        BigDecimal probability;
-
-        if (selectedTeam.equals(SelectedTeam.Team_A)) {
-            probability = match.getTotalAmountA().divide(total, 2, RoundingMode.HALF_UP);
-        } else {
-            probability = match.getTotalAmountB().divide(total, 2, RoundingMode.HALF_UP);
-        }
-
-        System.out.println("probability: " + probability);
-        return new BigDecimal("0.9").divide(probability, 2, RoundingMode.HALF_UP);
-    }
-
-    private String selectedTeamName(Match match, SelectedTeam selectedTeam) {
-        if (selectedTeam.equals(SelectedTeam.Team_A)) {
-            return match.getTeamA();
-        } else {
-            return match.getTeamB();
+        } catch (InterruptedException e) {
+            log.error("베팅 취소 락 대기 중 인터럽트 발생", e);
+            Thread.currentThread().interrupt();
+            throw new BetException(CommonErrorCode.INTERNAL_SERVER_ERROR);
+        } finally {
+            // 4. 락 해제
+            multiLock.unlock();
         }
     }
 }

--- a/src/main/java/org/example/oddventure/domain/bet/service/BetTransactionService.java
+++ b/src/main/java/org/example/oddventure/domain/bet/service/BetTransactionService.java
@@ -22,6 +22,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
+ * [신규 클래스]
  * 베팅 관련 DB 트랜잭션만을 전담하는 서비스
  * 분산 락이 획득된 상태에서만 호출되어야 함
  */
@@ -29,6 +30,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class BetTransactionService {
 
+    // dev BetService에 있던 DB Repository 의존성을 이곳으로 이동
     private final BetRepository betRepository;
     private final UserRepository userRepository;
     private final MatchRepository matchRepository;
@@ -75,8 +77,7 @@ public class BetTransactionService {
 
         bet.delete();
 
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+        User user = bet.getUser();
         user.plusPoint(bet.getBetAmount());
 
         refundTotalAmount(match, bet.getBetAmount(), bet.getSelectedTeam());
@@ -138,7 +139,6 @@ public class BetTransactionService {
         }
     }
 
-    // 트랜잭션 외부로 데이터를 전달하기 위한 내부 DTO
     public record CreateBetData(Bet bet, String selectedTeamName, BigDecimal userPointAfter, BigDecimal odds) {}
     public record DeleteBetData(Bet bet, User user) {}
 }

--- a/src/main/java/org/example/oddventure/domain/bet/service/BetTransactionService.java
+++ b/src/main/java/org/example/oddventure/domain/bet/service/BetTransactionService.java
@@ -116,6 +116,14 @@ public class BetTransactionService {
         }
     }
 
+    /***
+     * 승 배당률 = 0.9 / 승 금액 비율
+     * 0.9 = 1 - 0.1(수수료)
+     * 승 금액 비율 = 승 총 베팅 금액 / 전체 베팅 금액(승 + 패)
+     * 처음 배당률 지정 로직과
+     * 이후 배당률 조정 로직이 필요하다. (이는 베팅 생성시 호출된다.)
+     * 배당률 조정 로직 구현 시, 유저 비율도 고려하는 가중 조합형 배당률로 구현하는 것이 필요해 보인다.
+     */
     private BigDecimal calculateOdds(Match match, SelectedTeam selectedTeam) {
         BigDecimal total = match.getTotalAmountA().add(match.getTotalAmountB());
         System.out.println("total: " + total);

--- a/src/main/java/org/example/oddventure/domain/bet/service/BetTransactionService.java
+++ b/src/main/java/org/example/oddventure/domain/bet/service/BetTransactionService.java
@@ -1,0 +1,144 @@
+package org.example.oddventure.domain.bet.service;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import lombok.RequiredArgsConstructor;
+import org.example.oddventure.domain.bet.dto.request.BetCreateRequest;
+import org.example.oddventure.domain.bet.entity.Bet;
+import org.example.oddventure.domain.bet.enums.SelectedTeam;
+import org.example.oddventure.domain.bet.exception.BetErrorCode;
+import org.example.oddventure.domain.bet.exception.BetException;
+import org.example.oddventure.domain.bet.repository.BetRepository;
+import org.example.oddventure.domain.match.entity.Match;
+import org.example.oddventure.domain.match.enums.MatchStatus;
+import org.example.oddventure.domain.match.exception.MatchErrorCode;
+import org.example.oddventure.domain.match.exception.MatchException;
+import org.example.oddventure.domain.match.repository.MatchRepository;
+import org.example.oddventure.domain.user.entity.User;
+import org.example.oddventure.domain.user.exception.UserErrorCode;
+import org.example.oddventure.domain.user.exception.UserException;
+import org.example.oddventure.domain.user.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 베팅 관련 DB 트랜잭션만을 전담하는 서비스
+ * 분산 락이 획득된 상태에서만 호출되어야 함
+ */
+@Service
+@RequiredArgsConstructor
+public class BetTransactionService {
+
+    private final BetRepository betRepository;
+    private final UserRepository userRepository;
+    private final MatchRepository matchRepository;
+
+    @Transactional
+    public CreateBetData createBetInternal(Long userId, BetCreateRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+
+        BigDecimal betAmount = BigDecimal.valueOf(request.betAmount());
+
+        if (user.getPoint().compareTo(betAmount) < 0) {
+            throw new BetException(BetErrorCode.NOT_ENOUGH_POINTS);
+        }
+
+        Match match = matchRepository.findById(request.matchId())
+                .orElseThrow(() -> new MatchException(MatchErrorCode.MATCH_NOT_FOUND));
+
+        validateBettable(match);
+        user.minusPoint(betAmount);
+        BigDecimal odds = calculateOdds(match, request.selectedTeam());
+        updateTotalAmount(match, betAmount, request.selectedTeam());
+
+        Bet bet = request.toEntity(user, match, odds);
+        betRepository.save(bet);
+
+        String selectedTeamName = selectedTeamName(match, request.selectedTeam());
+
+        return new CreateBetData(bet, selectedTeamName, user.getPoint(), odds);
+    }
+
+    @Transactional
+    public DeleteBetData deleteBetInternal(Long userId, Long betId) {
+        Bet bet = betRepository.findByIdForDelete(betId)
+                .orElseThrow(() -> new BetException(BetErrorCode.BET_NOT_FOUND));
+
+        if (!bet.getUser().getId().equals(userId)) {
+            throw new BetException(BetErrorCode.PERMISSION_DENIED);
+        }
+
+        Match match = matchRepository.findById(bet.getMatch().getId())
+                .orElseThrow(() -> new MatchException(MatchErrorCode.MATCH_NOT_FOUND));
+        validateCancelable(match.getStatus());
+
+        bet.delete();
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+        user.plusPoint(bet.getBetAmount());
+
+        refundTotalAmount(match, bet.getBetAmount(), bet.getSelectedTeam());
+
+        return new DeleteBetData(bet, user);
+    }
+
+    private void validateBettable(Match match) {
+        if (match.isDeleted()) {
+            throw new BetException(BetErrorCode.MATCH_NOT_EXIST);
+        }
+        if (!match.getStatus().equals(MatchStatus.SCHEDULED)) {
+            throw new BetException(BetErrorCode.MATCH_NOT_BETTABLE);
+        }
+    }
+
+    private void validateCancelable(MatchStatus status) {
+        if (!status.equals(MatchStatus.SCHEDULED)) {
+            throw new BetException(BetErrorCode.MATCH_NOT_CANCELABLE);
+        }
+    }
+
+    private void updateTotalAmount(Match match, BigDecimal amount, SelectedTeam selectedTeam) {
+        if (selectedTeam.equals(SelectedTeam.Team_A)) {
+            match.plusTeamA(amount);
+        } else if (selectedTeam.equals(SelectedTeam.Team_B)) {
+            match.plusTeamB(amount);
+        }
+    }
+
+    private void refundTotalAmount(Match match, BigDecimal amount, SelectedTeam selectedTeam) {
+        if (selectedTeam.equals(SelectedTeam.Team_A)) {
+            match.minusTeamA(amount);
+        } else if (selectedTeam.equals(SelectedTeam.Team_B)) {
+            match.minusTeamB(amount);
+        }
+    }
+
+    private BigDecimal calculateOdds(Match match, SelectedTeam selectedTeam) {
+        BigDecimal total = match.getTotalAmountA().add(match.getTotalAmountB());
+        System.out.println("total: " + total);
+        BigDecimal probability;
+
+        if (selectedTeam.equals(SelectedTeam.Team_A)) {
+            probability = match.getTotalAmountA().divide(total, 2, RoundingMode.HALF_UP);
+        } else {
+            probability = match.getTotalAmountB().divide(total, 2, RoundingMode.HALF_UP);
+        }
+
+        System.out.println("probability: " + probability);
+        return new BigDecimal("0.9").divide(probability, 2, RoundingMode.HALF_UP);
+    }
+
+    private String selectedTeamName(Match match, SelectedTeam selectedTeam) {
+        if (selectedTeam.equals(SelectedTeam.Team_A)) {
+            return match.getTeamA();
+        } else {
+            return match.getTeamB();
+        }
+    }
+
+    // 트랜잭션 외부로 데이터를 전달하기 위한 내부 DTO
+    public record CreateBetData(Bet bet, String selectedTeamName, BigDecimal userPointAfter, BigDecimal odds) {}
+    public record DeleteBetData(Bet bet, User user) {}
+}

--- a/src/main/java/org/example/oddventure/domain/match/controller/MatchController.java
+++ b/src/main/java/org/example/oddventure/domain/match/controller/MatchController.java
@@ -40,6 +40,9 @@ public class MatchController {
     public ResponseEntity<ApiResponse<MatchResponse>> getMatch(
             @PathVariable Long matchId
     ) {
+        // 1. 조회수 증가(Write) 로직을 먼저 호출 (캐시와 무관하게 항상 실행)
+        matchService.incrementViewCount(matchId);
+        // 2. 캐시가 적용된 순수 조회(Read) 로직을 호출
         MatchResponse match = matchService.getMatch(matchId);
         return ApiResponse.success(match, "매치 상세 조회에 성공했습니다.");
     }

--- a/src/main/java/org/example/oddventure/domain/match/repository/MatchRepository.java
+++ b/src/main/java/org/example/oddventure/domain/match/repository/MatchRepository.java
@@ -1,13 +1,11 @@
 package org.example.oddventure.domain.match.repository;
 
-import jakarta.persistence.LockModeType;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.example.oddventure.domain.match.entity.Match;
 import org.example.oddventure.domain.match.enums.MatchStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -17,10 +15,6 @@ public interface MatchRepository extends JpaRepository<Match, Long>, MatchReposi
     @Modifying
     @Query("UPDATE Match m SET m.viewCount = m.viewCount + 1 WHERE m.id = :id")
     int incrementViewCount(@Param("id") Long matchId);
-
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("select m from Match m where m.id = :id")
-    Optional<Match> findByIdForUpdate(@Param("id") Long id);
 
     @Query("select m.winner from Match m where m.winner is not null")
     List<String> findByWinnerIsNotNull();

--- a/src/main/java/org/example/oddventure/domain/match/repository/MatchRepository.java
+++ b/src/main/java/org/example/oddventure/domain/match/repository/MatchRepository.java
@@ -13,10 +13,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 public interface MatchRepository extends JpaRepository<Match, Long>, MatchRepositoryCustom {
 
-    @Modifying
-    @Query("UPDATE Match m SET m.viewCount = m.viewCount + 1 WHERE m.id = :id")
-    int incrementViewCount(@Param("id") Long matchId);
-
     // 스케줄러가 Redis의 조회수 총합을 DB에 덮어쓰기(동기화)하기 위한 쿼리
     @Transactional
     @Modifying

--- a/src/main/java/org/example/oddventure/domain/match/repository/MatchRepository.java
+++ b/src/main/java/org/example/oddventure/domain/match/repository/MatchRepository.java
@@ -9,12 +9,19 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface MatchRepository extends JpaRepository<Match, Long>, MatchRepositoryCustom {
 
     @Modifying
     @Query("UPDATE Match m SET m.viewCount = m.viewCount + 1 WHERE m.id = :id")
     int incrementViewCount(@Param("id") Long matchId);
+
+    // 스케줄러가 Redis의 조회수 총합을 DB에 덮어쓰기(동기화)하기 위한 쿼리
+    @Transactional
+    @Modifying
+    @Query("UPDATE Match m SET m.viewCount = :count WHERE m.id = :id")
+    int updateViewCount(@Param("id") Long matchId, @Param("count") Long count);
 
     @Query("select m.winner from Match m where m.winner is not null")
     List<String> findByWinnerIsNotNull();

--- a/src/main/java/org/example/oddventure/domain/match/scheduler/MatchScheduler.java
+++ b/src/main/java/org/example/oddventure/domain/match/scheduler/MatchScheduler.java
@@ -13,6 +13,9 @@ import org.example.oddventure.domain.match.entity.Match;
 import org.example.oddventure.domain.match.enums.MatchStatus;
 import org.example.oddventure.domain.match.repository.MatchRepository;
 import org.example.oddventure.domain.match.service.MatchService;
+import org.springframework.data.redis.core.Cursor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -25,6 +28,7 @@ public class MatchScheduler {
     private final MatchService matchService;
     private final GridService gridService;
     private final BetService betService;
+    private final RedisTemplate<String, Object> redisTemplate;
 
     @Scheduled(cron = "0 0 13 * * *", zone = "Asia/Seoul")
     public void autoFinishMatches() {
@@ -64,5 +68,35 @@ public class MatchScheduler {
         } else {
             log.info("끝나지 않은 경기입니다. matchId={}, fetchId={}", match.getId(), match.getFetchId());
         }
+    }
+
+    // 5분마다 Redis의 조회수를 RDB로 동기화
+    @Scheduled(cron = "0 */5 * * * *") // 5분마다 실행
+    public void syncViewCountsToDB() {
+        log.info("Redis 조회수 DB 동기화 시작");
+        String pattern = "match:viewcount:*";
+        ScanOptions options = ScanOptions.scanOptions().match(pattern).count(100).build();
+        Cursor<String> cursor = redisTemplate.scan(options);
+
+        while (cursor.hasNext()) {
+            String key = cursor.next();
+            try {
+                // 1. Redis에서 현재 조회수 가져오기
+                Object rawValue = redisTemplate.opsForValue().get(key);
+                if (rawValue == null) continue;
+
+                Long viewCount = Long.parseLong(String.valueOf(rawValue));
+
+                // 2. Key에서 matchId 파싱 (예: "match:viewcount:1" -> "1")
+                Long matchId = Long.parseLong(key.substring(key.lastIndexOf(':') + 1));
+
+                // 3. MatchService의 @Transactional 메서드를 호출하여 DB 업데이트
+                matchService.updateViewCount(matchId, viewCount);
+
+            } catch (Exception e) {
+                log.error("키 처리 중 오류 발생: {} (key: {})", e.getMessage(), key);
+            }
+        }
+        log.info("Redis 조회수 DB 동기화 완료.");
     }
 }

--- a/src/main/java/org/example/oddventure/domain/match/service/MatchService.java
+++ b/src/main/java/org/example/oddventure/domain/match/service/MatchService.java
@@ -22,6 +22,7 @@ import org.example.oddventure.domain.match.repository.MatchRepository;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,6 +34,7 @@ public class MatchService {
     private final MatchRepository matchRepository;
     private final HotKeywordsService hotKeywordsService;
     private final MatchEventProducer matchEventProducer;
+    private final RedisTemplate<String, Object> redisTemplate;
 
     // 매치 생성 (매치별로 독립적인 트랜잭션 보유)
     @Transactional(propagation = REQUIRES_NEW)
@@ -74,17 +76,26 @@ public class MatchService {
         return matches.map(MatchResponse::from);
     }
 
-    @Transactional
     @Cacheable(value = "matchDetails", key = "#matchId", unless = "#result.status.name() != 'FINISHED'")
+    @Transactional(readOnly = true)
     public MatchResponse getMatch(Long matchId) {
-        int updated = matchRepository.incrementViewCount(matchId);
-        if (updated == 0) {
-            throw new MatchException(MatchErrorCode.MATCH_NOT_FOUND);
-        }
-
+        log.info("getMatch for matchId: {}", matchId);
         Match match = findMatchById(matchId);
-
         return MatchResponse.from(match);
+    }
+
+    // 조회수 증가 로직
+    public void incrementViewCount(Long matchId) {
+        String viewCountKey = "match:viewcount:" + matchId;
+        redisTemplate.opsForValue().increment(viewCountKey);
+    }
+
+    @Transactional
+    public void updateViewCount(Long matchId, Long viewCount) {
+        int updated = matchRepository.updateViewCount(matchId, viewCount);
+        if (updated == 0) {
+            log.warn("DB에 matchId: {}가 존재하지 않아 조회수 동기화 실패", matchId);
+        }
     }
 
     @Transactional

--- a/src/main/java/org/example/oddventure/domain/match/service/MatchService.java
+++ b/src/main/java/org/example/oddventure/domain/match/service/MatchService.java
@@ -18,6 +18,7 @@ import org.example.oddventure.domain.match.enums.MatchStatus;
 import org.example.oddventure.domain.match.exception.MatchErrorCode;
 import org.example.oddventure.domain.match.exception.MatchException;
 import org.example.oddventure.domain.match.repository.MatchRepository;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -77,6 +78,7 @@ public class MatchService {
     }
 
     @Transactional
+    @Cacheable(value = "matchDetails", key = "#matchId", unless = "#result.status.name() != 'FINISHED'")
     public MatchResponse getMatch(Long matchId) {
         int updated = matchRepository.incrementViewCount(matchId);
         if (updated == 0) {

--- a/src/main/java/org/example/oddventure/domain/team/service/TeamService.java
+++ b/src/main/java/org/example/oddventure/domain/team/service/TeamService.java
@@ -8,6 +8,7 @@ import org.example.oddventure.domain.team.dto.TeamResponse;
 import org.example.oddventure.domain.team.entity.Team;
 import org.example.oddventure.domain.team.exception.TeamException;
 import org.example.oddventure.domain.team.repository.TeamRepository;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -21,11 +22,13 @@ public class TeamService {
 
     private final TeamRepository teamRepository;
 
+    @Cacheable(value = "teamId", key = "#pageable")
     public Page<TeamResponse> getAllTeam(Pageable pageable) {
         Page<Team> team = teamRepository.findAll(pageable);
         return team.map(TeamResponse::of);
     }
 
+    @Cacheable(value = "teamDetail", key = "#id")
     public TeamResponse getTeamById(Long id) {
         Team team = teamRepository.findById(id)
                 .orElseThrow(() -> new TeamException(TEAM_NOT_FOUND));

--- a/src/main/java/org/example/oddventure/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/example/oddventure/domain/user/repository/UserRepository.java
@@ -1,12 +1,10 @@
 package org.example.oddventure.domain.user.repository;
 
-import jakarta.persistence.LockModeType;
 import java.util.Optional;
 import org.example.oddventure.domain.user.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -23,8 +21,4 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByEmail(String email);
 
     Optional<User> findByEmail(String email);
-
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("SELECT u FROM User u WHERE u.id = :id")
-    Optional<User> findByIdForUpdate(@Param("id") Long id);
 }

--- a/src/main/java/org/example/oddventure/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/example/oddventure/domain/user/repository/UserRepository.java
@@ -1,10 +1,12 @@
 package org.example.oddventure.domain.user.repository;
 
+import jakarta.persistence.LockModeType;
 import java.util.Optional;
 import org.example.oddventure.domain.user.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -21,4 +23,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByEmail(String email);
 
     Optional<User> findByEmail(String email);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT u FROM User u WHERE u.id = :id")
+    Optional<User> findByIdForUpdate(@Param("id") Long id);
 }

--- a/src/main/java/org/example/oddventure/domain/user/service/UserPointTransactionService.java
+++ b/src/main/java/org/example/oddventure/domain/user/service/UserPointTransactionService.java
@@ -1,0 +1,30 @@
+package org.example.oddventure.domain.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.oddventure.domain.admin.dto.request.PointAdjustRequest;
+import org.example.oddventure.domain.admin.exception.AdminErrorCode;
+import org.example.oddventure.domain.admin.exception.AdminException;
+import org.example.oddventure.domain.user.entity.User;
+import org.example.oddventure.domain.user.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 유저 포인트 관련 DB 트랜잭션만을 전담하는 서비스
+ * 분산 락이 획득된 상태에서만 호출되어야 함
+ */
+@Service
+@RequiredArgsConstructor
+public class UserPointTransactionService {
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    public User increaseUserPoint(Long userId, PointAdjustRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new AdminException(AdminErrorCode.USER_NOT_FOUND));
+
+        user.plusPoint(request.amount());
+        return user;
+    }
+}

--- a/src/main/java/org/example/oddventure/domain/user/service/UserService.java
+++ b/src/main/java/org/example/oddventure/domain/user/service/UserService.java
@@ -2,10 +2,10 @@ package org.example.oddventure.domain.user.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.example.oddventure.common.exception.CommonErrorCode;
 import org.example.oddventure.domain.admin.dto.request.PointAdjustRequest;
 import org.example.oddventure.domain.admin.dto.response.PointAdjustResponse;
-import org.example.oddventure.domain.admin.exception.AdminErrorCode;
-import org.example.oddventure.domain.admin.exception.AdminException;
+import org.example.oddventure.domain.bet.exception.BetException;
 import org.example.oddventure.domain.user.dto.request.PasswordUpdateRequest;
 import org.example.oddventure.domain.user.dto.request.ProfileUpdateRequest;
 import org.example.oddventure.domain.user.dto.response.UserProfileResponse;
@@ -13,6 +13,9 @@ import org.example.oddventure.domain.user.entity.User;
 import org.example.oddventure.domain.user.exception.UserErrorCode;
 import org.example.oddventure.domain.user.exception.UserException;
 import org.example.oddventure.domain.user.repository.UserRepository;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import java.util.concurrent.TimeUnit;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,6 +27,9 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final RedissonClient redissonClient;
+    private final UserPointTransactionService userPointTransactionService;
+    private static final String POINT_LOCK_PREFIX = "LOCK:USER_POINT:";
 
     @Transactional(readOnly = true)
     public UserProfileResponse getUserProfile(Long userId) {
@@ -59,23 +65,39 @@ public class UserService {
         user.updatePassword(newEncodedPassword);
     }
 
-    // 포인트 지급
-    @Transactional
     public PointAdjustResponse adjustUserPoints(Long userId, PointAdjustRequest request) {
-        User user = userRepository.findByIdForUpdate(userId)
-                .orElseThrow(() -> new AdminException(AdminErrorCode.USER_NOT_FOUND));
+        String lockKey = POINT_LOCK_PREFIX + userId;
+        RLock lock = redissonClient.getLock(lockKey);
 
-        user.plusPoint(request.amount());
+        try {
+            boolean isLocked = lock.tryLock(10, 5, TimeUnit.SECONDS);
 
-        log.info("[ADMIN_POINT_ADJUSTMENT] userId={}, amount={}, reason='{}', finalBalance={}",
-                userId, request.amount(), request.reason(), user.getPoint());
+            if (!isLocked) {
+                log.warn("포인트 지급 락 획득 실패. userId: {}", userId);
+                throw new BetException(org.example.oddventure.domain.bet.exception.BetErrorCode.BET_LOCK_FAILED);
+            }
 
-        return new PointAdjustResponse(
-                user.getId(),
-                user.getUsername(),
-                request.amount(),
-                user.getPoint()
-        );
+            User user = userPointTransactionService.increaseUserPoint(userId, request);
+
+            log.info("[ADMIN_POINT_ADJUSTMENT] userId={}, amount={}, reason='{}', finalBalance={}",
+                    userId, request.amount(), request.reason(), user.getPoint());
+
+            return new PointAdjustResponse(
+                    user.getId(),
+                    user.getUsername(),
+                    request.amount(),
+                    user.getPoint()
+            );
+
+        } catch (InterruptedException e) {
+            log.error("포인트 지급 락 대기 중 인터럽트 발생", e);
+            Thread.currentThread().interrupt();
+            throw new UserException(CommonErrorCode.INTERNAL_SERVER_ERROR);
+        } finally {
+            if (lock.isLocked() && lock.isHeldByCurrentThread()) {
+                lock.unlock();
+            }
+        }
     }
 
     private User findUserById(Long userId) {

--- a/src/main/java/org/example/oddventure/domain/user/service/UserService.java
+++ b/src/main/java/org/example/oddventure/domain/user/service/UserService.java
@@ -62,7 +62,7 @@ public class UserService {
     // 포인트 지급
     @Transactional
     public PointAdjustResponse adjustUserPoints(Long userId, PointAdjustRequest request) {
-        User user = userRepository.findById(userId)
+        User user = userRepository.findByIdForUpdate(userId)
                 .orElseThrow(() -> new AdminException(AdminErrorCode.USER_NOT_FOUND));
 
         user.plusPoint(request.amount());

--- a/src/test/java/org/example/oddventure/domain/bet/unit/BetServiceConcurrencyTest.java
+++ b/src/test/java/org/example/oddventure/domain/bet/unit/BetServiceConcurrencyTest.java
@@ -1,0 +1,134 @@
+package org.example.oddventure.domain.bet.unit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.example.oddventure.domain.bet.dto.request.BetCreateRequest;
+import org.example.oddventure.domain.bet.enums.SelectedTeam;
+import org.example.oddventure.domain.bet.exception.BetException;
+import org.example.oddventure.domain.bet.repository.BetRepository;
+import org.example.oddventure.domain.bet.service.BetService;
+import org.example.oddventure.domain.match.entity.Match;
+import org.example.oddventure.domain.match.repository.MatchRepository;
+import org.example.oddventure.domain.user.entity.User;
+import org.example.oddventure.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class BetServiceConcurrencyTest {
+
+    @Autowired
+    private BetService betService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private MatchRepository matchRepository;
+
+    @Autowired
+    private BetRepository betRepository;
+
+    private User testUser;
+    private Match testMatch;
+
+    @BeforeEach
+    void setUp() {
+        // 1000 포인트를 가진 유저 생성
+        User user = User.builder()
+                .username("bettingUser")
+                .email("bet@test.com")
+                .password("password")
+                .build();
+        testUser = userRepository.saveAndFlush(user);
+        assertThat(testUser.getPoint()).isEqualByComparingTo(new BigDecimal("1000"));
+
+        Match match = Match.builder()
+                .matchName("LCK")
+                .teamA("T1")
+                .teamB("GEN.G")
+                .startTime(LocalDateTime.now().plusDays(1))
+                .build();
+        match.plusTeamA(new BigDecimal("100"));
+        match.plusTeamB(new BigDecimal("100"));
+        testMatch = matchRepository.saveAndFlush(match);
+    }
+
+    /**
+     * 테스트 실행 후, 생성된 데이터를 모두 삭제
+     */
+    @AfterEach
+    void tearDown() {
+        betRepository.deleteAll();
+        matchRepository.deleteById(testMatch.getId());
+        userRepository.deleteById(testUser.getId());
+    }
+
+    /**
+     * 1000 포인트를 가진 사용자가 100 포인트 베팅을 20회 동시 시도할 때,
+     * 정확히 10회만 성공하고 10회는 "포인트 부족" 예외가 발생하며,
+     * 사용자의 최종 잔액은 0원이 되는지 테스트함
+     */
+    @Test
+    @DisplayName("1000포인트 유저가 100포인트 베팅 20회 동시 시도 시, 10회만 성공하고 잔액은 0이 된다")
+    void createBet_ConcurrencyTest_SuccessAndFailure() throws InterruptedException {
+        // given
+        int threadCount = 20;
+        long betAmount = 100L; // 100 포인트 베팅
+
+        ExecutorService executorService = Executors.newFixedThreadPool(32);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        // 동시성 환경에서 성공/실패 카운트를 위한 Atomic 변수
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failCount = new AtomicInteger(0);
+
+        BetCreateRequest request = new BetCreateRequest(testMatch.getId(), SelectedTeam.Team_A, betAmount);
+
+        // when
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    betService.createBet(testUser.getId(), request);
+                    successCount.incrementAndGet(); // 성공
+                } catch (BetException e) {
+                    if (e.getErrorCode().getMessage().contains("부족")) {
+                        failCount.incrementAndGet(); // "보유 포인트가 부족합니다." 예외 시 실패
+                    }
+                } catch (Exception e) {
+                    // 디버깅을 위해 다른 예외도 출력
+                    System.err.println("Unexpected exception: " + e.getMessage());
+                    e.printStackTrace();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+        executorService.shutdown();
+
+        // then
+        // DB에서 최종 사용자 정보 및 베팅 내역 조회
+        User updatedUser = userRepository.findById(testUser.getId()).orElseThrow();
+        long betCount = betRepository.count();
+
+        // 10번은 성공
+        assertThat(successCount.get()).isEqualTo(10);
+        // 10번은 포인트 부족으로 실패
+        assertThat(failCount.get()).isEqualTo(10);
+        // DB에 저장된 Bet 엔티티도 10개
+        assertThat(betCount).isEqualTo(10);
+        // 유저의 최종 잔액은 0 (1000 - 100 * 10)
+        assertThat(updatedUser.getPoint()).isEqualByComparingTo(BigDecimal.ZERO);
+    }
+}

--- a/src/test/java/org/example/oddventure/domain/bet/unit/BetServiceConcurrencyTest.java
+++ b/src/test/java/org/example/oddventure/domain/bet/unit/BetServiceConcurrencyTest.java
@@ -7,8 +7,10 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.example.oddventure.base.RedisTestContainerConfig;
 import org.example.oddventure.domain.bet.dto.request.BetCreateRequest;
 import org.example.oddventure.domain.bet.enums.SelectedTeam;
+import org.example.oddventure.domain.bet.exception.BetErrorCode;
 import org.example.oddventure.domain.bet.exception.BetException;
 import org.example.oddventure.domain.bet.repository.BetRepository;
 import org.example.oddventure.domain.bet.service.BetService;
@@ -22,9 +24,11 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
-public class BetServiceConcurrencyTest {
+@ActiveProfiles("test")
+public class BetServiceConcurrencyTest extends RedisTestContainerConfig {
 
     @Autowired
     private BetService betService;
@@ -79,7 +83,7 @@ public class BetServiceConcurrencyTest {
      * 사용자의 최종 잔액은 0원이 되는지 테스트함
      */
     @Test
-    @DisplayName("1000포인트 유저가 100포인트 베팅 20회 동시 시도 시, 10회만 성공하고 잔액은 0이 된다")
+    @DisplayName("1000포인트 유저가 100포인트 베팅 20회 동시 시도 시, 10회만 성공하고 잔액은 0이 된다 (분산 락)")
     void createBet_ConcurrencyTest_SuccessAndFailure() throws InterruptedException {
         // given
         int threadCount = 20;
@@ -87,11 +91,8 @@ public class BetServiceConcurrencyTest {
 
         ExecutorService executorService = Executors.newFixedThreadPool(32);
         CountDownLatch latch = new CountDownLatch(threadCount);
-
-        // 동시성 환경에서 성공/실패 카운트를 위한 Atomic 변수
         AtomicInteger successCount = new AtomicInteger(0);
         AtomicInteger failCount = new AtomicInteger(0);
-
         BetCreateRequest request = new BetCreateRequest(testMatch.getId(), SelectedTeam.Team_A, betAmount);
 
         // when
@@ -101,11 +102,14 @@ public class BetServiceConcurrencyTest {
                     betService.createBet(testUser.getId(), request);
                     successCount.incrementAndGet(); // 성공
                 } catch (BetException e) {
-                    if (e.getErrorCode().getMessage().contains("부족")) {
-                        failCount.incrementAndGet(); // "보유 포인트가 부족합니다." 예외 시 실패
+                    // 락 획득 실패(BET_LOCK_FAILED) 또는 포인트 부족(NOT_ENOUGH_POINTS) 모두 실패로 간주
+                    if (e.getErrorCode() == BetErrorCode.NOT_ENOUGH_POINTS ||
+                            e.getErrorCode() == BetErrorCode.BET_LOCK_FAILED) {
+                        failCount.incrementAndGet();
+                    } else {
+                        e.printStackTrace();
                     }
                 } catch (Exception e) {
-                    // 디버깅을 위해 다른 예외도 출력
                     System.err.println("Unexpected exception: " + e.getMessage());
                     e.printStackTrace();
                 } finally {
@@ -118,17 +122,19 @@ public class BetServiceConcurrencyTest {
         executorService.shutdown();
 
         // then
-        // DB에서 최종 사용자 정보 및 베팅 내역 조회
         User updatedUser = userRepository.findById(testUser.getId()).orElseThrow();
         long betCount = betRepository.count();
 
-        // 10번은 성공
-        assertThat(successCount.get()).isEqualTo(10);
-        // 10번은 포인트 부족으로 실패
-        assertThat(failCount.get()).isEqualTo(10);
-        // DB에 저장된 Bet 엔티티도 10개
-        assertThat(betCount).isEqualTo(10);
-        // 유저의 최종 잔액은 0 (1000 - 100 * 10)
-        assertThat(updatedUser.getPoint()).isEqualByComparingTo(BigDecimal.ZERO);
+        // 분산 락은 DB 락보다 락 획득/해제 속도가 빨라서 10회/10회(50%)가 아닌 11회/9회 등으로 결과가 나올 수 있음
+        // 중요한 것은 (성공 횟수 * 베팅금액) == (차감된 포인트)
+        BigDecimal totalBetAmount = new BigDecimal(betAmount).multiply(new BigDecimal(successCount.get()));
+        BigDecimal expectedPoint = new BigDecimal("1000").subtract(totalBetAmount);
+
+        // 1. 성공 횟수 + 실패 횟수 = 총 20회
+        assertThat(successCount.get() + failCount.get()).isEqualTo(20);
+        // 2. DB에 저장된 Bet 엔티티 == 성공 횟수
+        assertThat(betCount).isEqualTo(successCount.get());
+        // 3. 유저의 최종 잔액 == 1000 - (성공 횟수 * 100)
+        assertThat(updatedUser.getPoint()).isEqualByComparingTo(expectedPoint);
     }
 }

--- a/src/test/java/org/example/oddventure/domain/bet/unit/BetServiceTest.java
+++ b/src/test/java/org/example/oddventure/domain/bet/unit/BetServiceTest.java
@@ -90,7 +90,7 @@ public class BetServiceTest {
         ReflectionTestUtils.setField(bet, "id", betId);
 
         given(betRepository.save(any(Bet.class))).willReturn(bet);
-        given(userRepository.findById(anyLong())).willReturn(Optional.of(user));
+        given(userRepository.findByIdForUpdate(anyLong())).willReturn(Optional.of(user));
         given(matchRepository.findByIdForUpdate(anyLong())).willReturn(Optional.of(match));
 
         //when
@@ -142,6 +142,7 @@ public class BetServiceTest {
 
         given(betRepository.findByIdForDelete(anyLong())).willReturn(Optional.of(bet));
         given(matchRepository.findByIdForUpdate(anyLong())).willReturn(Optional.of(match));
+        given(userRepository.findByIdForUpdate(anyLong())).willReturn(Optional.of(user));
 
         //when
         BetDeleteResponse response = betService.deleteBet(user.getId(), betId);

--- a/src/test/java/org/example/oddventure/domain/bet/unit/BetServiceTest.java
+++ b/src/test/java/org/example/oddventure/domain/bet/unit/BetServiceTest.java
@@ -97,8 +97,6 @@ public class BetServiceTest {
         given(redissonClient.getLock("LOCK:MATCH:" + matchId)).willReturn(matchLock);
         given(redissonClient.getMultiLock(userLock, matchLock)).willReturn(multiLock);
         given(multiLock.tryLock(10, 5, TimeUnit.SECONDS)).willReturn(true); // 락 획득 성공
-        given(multiLock.isLocked()).willReturn(true);
-        given(multiLock.isHeldByCurrentThread()).willReturn(true);
 
         // 트랜잭션 서비스 호출 Mocking
         given(betTransactionService.createBetInternal(userId, request)).willReturn(createBetData);
@@ -145,8 +143,6 @@ public class BetServiceTest {
         given(redissonClient.getLock("LOCK:MATCH:" + matchId)).willReturn(matchLock);
         given(redissonClient.getMultiLock(userLock, matchLock)).willReturn(multiLock);
         given(multiLock.tryLock(10, 5, TimeUnit.SECONDS)).willReturn(true); // 락 획득 성공
-        given(multiLock.isLocked()).willReturn(true);
-        given(multiLock.isHeldByCurrentThread()).willReturn(true);
 
         // 트랜잭션 서비스 호출 Mocking
         given(betTransactionService.deleteBetInternal(userId, betId)).willReturn(deleteBetData);

--- a/src/test/java/org/example/oddventure/domain/bet/unit/BetServiceTest.java
+++ b/src/test/java/org/example/oddventure/domain/bet/unit/BetServiceTest.java
@@ -97,6 +97,8 @@ public class BetServiceTest {
         given(redissonClient.getLock("LOCK:MATCH:" + matchId)).willReturn(matchLock);
         given(redissonClient.getMultiLock(userLock, matchLock)).willReturn(multiLock);
         given(multiLock.tryLock(10, 5, TimeUnit.SECONDS)).willReturn(true); // 락 획득 성공
+        given(multiLock.isLocked()).willReturn(true);
+        given(multiLock.isHeldByCurrentThread()).willReturn(true);
 
         // 트랜잭션 서비스 호출 Mocking
         given(betTransactionService.createBetInternal(userId, request)).willReturn(createBetData);
@@ -143,6 +145,8 @@ public class BetServiceTest {
         given(redissonClient.getLock("LOCK:MATCH:" + matchId)).willReturn(matchLock);
         given(redissonClient.getMultiLock(userLock, matchLock)).willReturn(multiLock);
         given(multiLock.tryLock(10, 5, TimeUnit.SECONDS)).willReturn(true); // 락 획득 성공
+        given(multiLock.isLocked()).willReturn(true);
+        given(multiLock.isHeldByCurrentThread()).willReturn(true);
 
         // 트랜잭션 서비스 호출 Mocking
         given(betTransactionService.deleteBetInternal(userId, betId)).willReturn(deleteBetData);

--- a/src/test/java/org/example/oddventure/domain/bet/unit/BetServiceTest.java
+++ b/src/test/java/org/example/oddventure/domain/bet/unit/BetServiceTest.java
@@ -3,7 +3,6 @@ package org.example.oddventure.domain.bet.unit;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
@@ -11,6 +10,7 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import org.example.oddventure.domain.bet.dto.request.BetCreateRequest;
 import org.example.oddventure.domain.bet.dto.response.BetCreateResponse;
 import org.example.oddventure.domain.bet.dto.response.BetDeleteResponse;
@@ -19,17 +19,18 @@ import org.example.oddventure.domain.bet.entity.Bet;
 import org.example.oddventure.domain.bet.enums.SelectedTeam;
 import org.example.oddventure.domain.bet.repository.BetRepository;
 import org.example.oddventure.domain.bet.service.BetService;
+import org.example.oddventure.domain.bet.service.BetTransactionService;
 import org.example.oddventure.domain.event.RedisPublisher;
 import org.example.oddventure.domain.match.entity.Match;
-import org.example.oddventure.domain.match.repository.MatchRepository;
 import org.example.oddventure.domain.user.entity.User;
-import org.example.oddventure.domain.user.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -46,55 +47,57 @@ public class BetServiceTest {
     private BetRepository betRepository;
 
     @Mock
-    private MatchRepository matchRepository;
-
-    @Mock
-    private UserRepository userRepository;
-
-    @Mock
     private RedisPublisher redisPublisher;
 
+    @Mock
+    private RedissonClient redissonClient;
+
+    @Mock
+    private BetTransactionService betTransactionService;
+
+    @Mock
+    private RLock multiLock;
+
+    @Mock
+    private RLock userLock;
+
+    @Mock
+    private RLock matchLock;
+
     @Test
-    @DisplayName("베팅을 생성 성공하면 유저 포인트가 차감되고 베팅 금액이 저장된다.")
-    void createBet_success() {
+    @DisplayName("베팅을 생성 성공 (분산 락)")
+    void createBet_success() throws InterruptedException {
         //given
         Long userId = 1L;
-        User user = User.builder()
-                .username("test")
-                .email("test1234@test.com")
-                .password("test1234!")
-                .build();
-        ReflectionTestUtils.setField(user, "id", userId);
-
         Long matchId = 1L;
-        Match match = Match.builder()
-                .teamA("T1")
-                .teamB("GEN.G")
-                .startTime(LocalDateTime.now().plusDays(1))
-                .build();
+        Long betId = 1L;
+
+        User user = User.builder().build(); // 트랜잭션 서비스가 반환할 객체
+        Match match = Match.builder().teamA("T1").build(); // 트랜잭션 서비스가 반환할 객체
         ReflectionTestUtils.setField(match, "id", matchId);
 
-        match.plusTeamA(new BigDecimal("6000"));
-        match.plusTeamB(new BigDecimal("4000"));
+        BetCreateRequest request = new BetCreateRequest(matchId, SelectedTeam.Team_A, 1000L);
 
-        BetCreateRequest request = new BetCreateRequest(1L, SelectedTeam.Team_A, 1000L);
-
-        Long betId = 1L;
-        Bet bet = Bet.builder()
-                .user(user)
-                .match(match)
-                .selectedTeam(SelectedTeam.Team_A)
-                .betAmount(new BigDecimal("1000"))
-                .oddsAtBetting(new BigDecimal("2"))
-                .build();
+        // 트랜잭션 서비스가 반환할 데이터 Mocking
+        Bet bet = Bet.builder().user(user).match(match).selectedTeam(SelectedTeam.Team_A)
+                .betAmount(new BigDecimal(1000)).oddsAtBetting(new BigDecimal("1.50")).build();
         ReflectionTestUtils.setField(bet, "id", betId);
 
-        given(betRepository.save(any(Bet.class))).willReturn(bet);
-        given(userRepository.findByIdForUpdate(anyLong())).willReturn(Optional.of(user));
-        given(matchRepository.findByIdForUpdate(anyLong())).willReturn(Optional.of(match));
+        BetTransactionService.CreateBetData createBetData = new BetTransactionService.CreateBetData(
+                bet, "T1", new BigDecimal("0"), new BigDecimal("1.50")
+        );
+
+        // Redisson MultiLock Mocking
+        given(redissonClient.getLock("LOCK:USER_POINT:" + userId)).willReturn(userLock);
+        given(redissonClient.getLock("LOCK:MATCH:" + matchId)).willReturn(matchLock);
+        given(redissonClient.getMultiLock(userLock, matchLock)).willReturn(multiLock);
+        given(multiLock.tryLock(10, 5, TimeUnit.SECONDS)).willReturn(true); // 락 획득 성공
+
+        // 트랜잭션 서비스 호출 Mocking
+        given(betTransactionService.createBetInternal(userId, request)).willReturn(createBetData);
 
         //when
-        BetCreateResponse response = betService.createBet(user.getId(), request);
+        BetCreateResponse response = betService.createBet(userId, request);
 
         //then
         assertThat(response.selectedTeam()).isEqualTo(SelectedTeam.Team_A);
@@ -102,56 +105,50 @@ public class BetServiceTest {
         assertThat(response.betAmount()).isEqualTo(new BigDecimal("1000"));
         assertThat(response.oddsAtBetting()).isEqualTo(new BigDecimal("1.50"));
         assertThat(response.userPointAfter()).isEqualTo(new BigDecimal("0"));
-        verify(betRepository).save(any(Bet.class));
+        verify(multiLock).unlock(); // 락이 해제되었는지 검증
+        verify(redisPublisher).publish(any(String.class), any()); // 이벤트가 발행되었는지 검증
     }
 
     @Test
-    @DisplayName("베팅 삭제에 성공하면 포인트가 환불되고 베팅 금액이 감소된다.")
-    void deleteBet_success() {
+    @DisplayName("베팅 삭제에 성공 (분산 락)")
+    void deleteBet_success() throws InterruptedException {
         //given
         Long userId = 1L;
-        User user = User.builder()
-                .username("test")
-                .email("test1234@test.com")
-                .password("test1234!")
-                .build();
-        ReflectionTestUtils.setField(user, "id", userId);
-
+        Long betId = 1L;
         Long matchId = 1L;
-        Match match = Match.builder()
-                .teamA("T1")
-                .teamB("GEN.G")
-                .startTime(LocalDateTime.now().plusDays(1))
-                .build();
+
+        User user = User.builder().username("test").build(); // 트랜잭션 서비스가 반환할 객체
+        ReflectionTestUtils.setField(user, "id", userId);
+        user.plusPoint(new BigDecimal("1000")); // 1000(기본)+1000(환불) = 2000
+
+        Match match = Match.builder().build();
         ReflectionTestUtils.setField(match, "id", matchId);
 
-        match.plusTeamA(new BigDecimal("6000"));
-        match.plusTeamB(new BigDecimal("4000"));
-
-        Long betId = 1L;
-        Bet bet = Bet.builder()
-                .user(user)
-                .match(match)
-                .selectedTeam(SelectedTeam.Team_A)
-                .betAmount(new BigDecimal("1000"))
-                .oddsAtBetting(new BigDecimal("2"))
-                .build();
+        Bet bet = Bet.builder().user(user).match(match).betAmount(new BigDecimal("1000")).build();
         ReflectionTestUtils.setField(bet, "id", betId);
 
-        match.plusTeamA(bet.getBetAmount());
+        // 트랜잭션 서비스가 반환할 데이터 Mocking
+        BetTransactionService.DeleteBetData deleteBetData = new BetTransactionService.DeleteBetData(bet, user);
 
-        given(betRepository.findByIdForDelete(anyLong())).willReturn(Optional.of(bet));
-        given(matchRepository.findByIdForUpdate(anyLong())).willReturn(Optional.of(match));
-        given(userRepository.findByIdForUpdate(anyLong())).willReturn(Optional.of(user));
+        // 락 획득 전 betId로 매치를 찾기 위한 Mocking (preFetch)
+        given(betRepository.findById(betId)).willReturn(Optional.of(bet));
+
+        // Redisson MultiLock Mocking
+        given(redissonClient.getLock("LOCK:USER_POINT:" + userId)).willReturn(userLock);
+        given(redissonClient.getLock("LOCK:MATCH:" + matchId)).willReturn(matchLock);
+        given(redissonClient.getMultiLock(userLock, matchLock)).willReturn(multiLock);
+        given(multiLock.tryLock(10, 5, TimeUnit.SECONDS)).willReturn(true); // 락 획득 성공
+
+        // 트랜잭션 서비스 호출 Mocking
+        given(betTransactionService.deleteBetInternal(userId, betId)).willReturn(deleteBetData);
 
         //when
-        BetDeleteResponse response = betService.deleteBet(user.getId(), betId);
+        BetDeleteResponse response = betService.deleteBet(userId, betId);
 
         //then
-        assertThat(bet.isDeleted()).isTrue();
         assertThat(response.refundAmount()).isEqualTo(new BigDecimal("1000"));
-        assertThat(response.userPointAfter()).isEqualTo(new BigDecimal("2000"));
-        assertThat(match.getTotalAmountA()).isEqualTo(new BigDecimal("6000"));
+        assertThat(response.userPointAfter()).isEqualTo(new BigDecimal("2000")); // 기본 1000 + 환불 1000
+        verify(multiLock).unlock(); // 락이 해제되었는지 검증
     }
 
     @Test

--- a/src/test/java/org/example/oddventure/domain/bet/unit/BetTransactionServiceTest.java
+++ b/src/test/java/org/example/oddventure/domain/bet/unit/BetTransactionServiceTest.java
@@ -1,0 +1,205 @@
+package org.example.oddventure.domain.bet.unit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.example.oddventure.domain.bet.dto.request.BetCreateRequest;
+import org.example.oddventure.domain.bet.entity.Bet;
+import org.example.oddventure.domain.bet.enums.SelectedTeam;
+import org.example.oddventure.domain.bet.exception.BetErrorCode;
+import org.example.oddventure.domain.bet.exception.BetException;
+import org.example.oddventure.domain.bet.repository.BetRepository;
+import org.example.oddventure.domain.bet.service.BetTransactionService;
+import org.example.oddventure.domain.match.entity.Match;
+import org.example.oddventure.domain.match.enums.MatchStatus;
+import org.example.oddventure.domain.match.repository.MatchRepository;
+import org.example.oddventure.domain.user.entity.User;
+import org.example.oddventure.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+public class BetTransactionServiceTest {
+
+    @InjectMocks
+    private BetTransactionService betTransactionService;
+
+    @Mock
+    private BetRepository betRepository;
+
+    @Mock
+    private MatchRepository matchRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    private User user;
+    private Match match;
+
+    @BeforeEach
+    void setUp() {
+        // 공통 유저 Mock 생성 (기본 1000 포인트)
+        user = User.builder()
+                .username("test")
+                .email("test1234@test.com")
+                .password("test1234!")
+                .build();
+        ReflectionTestUtils.setField(user, "id", 1L);
+
+        // 공통 매치 Mock 생성 (SCHEDULED 상태)
+        match = Match.builder()
+                .teamA("T1")
+                .teamB("GEN.G")
+                .startTime(LocalDateTime.now().plusDays(1))
+                .build();
+        ReflectionTestUtils.setField(match, "id", 1L);
+
+        // calculateOdds()가 0으로 나누기 오류를 방지하도록 초기값 설정
+        match.plusTeamA(new BigDecimal("100"));
+        match.plusTeamB(new BigDecimal("100"));
+    }
+
+    @Nested
+    @DisplayName("베팅 생성 트랜잭션")
+    class CreateBetInternal {
+
+        @Test
+        @DisplayName("성공 - 유저 포인트가 차감되고 베팅 금액이 저장된다")
+        void createBetInternal_success() {
+            //given
+            BetCreateRequest request = new BetCreateRequest(1L, SelectedTeam.Team_A, 100L);
+            BigDecimal initialPoint = user.getPoint(); // 1000
+
+            given(userRepository.findById(1L)).willReturn(Optional.of(user));
+            given(matchRepository.findById(1L)).willReturn(Optional.of(match));
+            given(betRepository.save(any(Bet.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+            //when
+            BetTransactionService.CreateBetData data = betTransactionService.createBetInternal(1L, request);
+
+            //then
+            assertThat(data.userPointAfter()).isEqualTo(initialPoint.subtract(new BigDecimal(100))); // 900
+            assertThat(user.getPoint()).isEqualTo(new BigDecimal("900")); // User 객체 상태 변경 확인
+            assertThat(match.getTotalAmountA()).isEqualTo(new BigDecimal("200")); // 100(초기값) + 100(베팅)
+        }
+
+        @Test
+        @DisplayName("실패 - 보유 포인트 부족")
+        void createBetInternal_fail_notEnoughPoints() {
+            //given
+            // 2000 포인트 베팅 요청 (보유: 1000)
+            BetCreateRequest request = new BetCreateRequest(1L, SelectedTeam.Team_A, 2000L);
+            given(userRepository.findById(1L)).willReturn(Optional.of(user));
+
+            //when & then
+            BetException exception = assertThrows(BetException.class, () -> {
+                betTransactionService.createBetInternal(1L, request);
+            });
+            assertThat(exception.getErrorCode()).isEqualTo(BetErrorCode.NOT_ENOUGH_POINTS);
+        }
+
+        @Test
+        @DisplayName("실패 - 베팅 불가능한 매치 (ONGOING)")
+        void createBetInternal_fail_matchNotBettable() {
+            //given
+            match.setStatus(MatchStatus.ONGOING); // 경기 상태 변경
+            BetCreateRequest request = new BetCreateRequest(1L, SelectedTeam.Team_A, 100L);
+
+            given(userRepository.findById(1L)).willReturn(Optional.of(user));
+            given(matchRepository.findById(1L)).willReturn(Optional.of(match));
+
+            //when & then
+            BetException exception = assertThrows(BetException.class, () -> {
+                betTransactionService.createBetInternal(1L, request);
+            });
+            assertThat(exception.getErrorCode()).isEqualTo(BetErrorCode.MATCH_NOT_BETTABLE);
+        }
+    }
+
+    @Nested
+    @DisplayName("베팅 취소 트랜잭션")
+    class DeleteBetInternal {
+
+        @Test
+        @DisplayName("성공 - 포인트가 환불되고 베팅 금액이 복구된다")
+        void deleteBetInternal_success() {
+            //given
+            Long userId = 1L;
+            Long betId = 1L;
+            BigDecimal betAmount = new BigDecimal("100");
+
+            Bet bet = Bet.builder()
+                    .user(user)
+                    .match(match)
+                    .selectedTeam(SelectedTeam.Team_A)
+                    .betAmount(betAmount)
+                    .oddsAtBetting(new BigDecimal("1.5"))
+                    .build();
+
+            BigDecimal initialPoint = user.getPoint(); // 1000
+            BigDecimal initialMatchAmount = match.getTotalAmountA(); // 100
+
+            given(betRepository.findByIdForDelete(betId)).willReturn(Optional.of(bet));
+            given(matchRepository.findById(match.getId())).willReturn(Optional.of(match));
+
+            //when
+            BetTransactionService.DeleteBetData data = betTransactionService.deleteBetInternal(userId, betId);
+
+            //then
+            assertThat(bet.isDeleted()).isTrue(); // 논리적 삭제 확인
+            assertThat(user.getPoint()).isEqualTo(initialPoint.add(betAmount)); // 1100
+            assertThat(match.getTotalAmountA()).isEqualTo(initialMatchAmount.subtract(betAmount)); // 0
+            assertThat(data.user().getPoint()).isEqualTo(new BigDecimal("1100"));
+        }
+
+        @Test
+        @DisplayName("실패 - 베팅 소유자가 아님")
+        void deleteBetInternal_fail_permissionDenied() {
+            //given
+            Long otherUserId = 2L; // 다른 유저 ID
+            Long betId = 1L;
+
+            Bet bet = Bet.builder().user(user).match(match).build(); // bet은 1L 유저 소유
+
+            given(betRepository.findByIdForDelete(betId)).willReturn(Optional.of(bet));
+
+            //when & then
+            // 2L 유저가 1L 유저의 베팅 취소 시도
+            BetException exception = assertThrows(BetException.class, () -> {
+                betTransactionService.deleteBetInternal(otherUserId, betId);
+            });
+            assertThat(exception.getErrorCode()).isEqualTo(BetErrorCode.PERMISSION_DENIED);
+        }
+
+        @Test
+        @DisplayName("실패 - 취소 불가능한 매치 (FINISHED)")
+        void deleteBetInternal_fail_matchNotCancelable() {
+            //given
+            Long userId = 1L;
+            Long betId = 1L;
+            match.finishMatch("T1", "GEN.G"); // 경기 상태 FINISHED로 변경
+
+            Bet bet = Bet.builder().user(user).match(match).build();
+
+            given(betRepository.findByIdForDelete(betId)).willReturn(Optional.of(bet));
+            given(matchRepository.findById(match.getId())).willReturn(Optional.of(match));
+
+            //when & then
+            BetException exception = assertThrows(BetException.class, () -> {
+                betTransactionService.deleteBetInternal(userId, betId);
+            });
+            assertThat(exception.getErrorCode()).isEqualTo(BetErrorCode.MATCH_NOT_CANCELABLE);
+        }
+    }
+}

--- a/src/test/java/org/example/oddventure/domain/match/unit/MatchRepositoryTest.java
+++ b/src/test/java/org/example/oddventure/domain/match/unit/MatchRepositoryTest.java
@@ -30,8 +30,8 @@ public class MatchRepositoryTest {
     private EntityManager entityManager;
 
     @Test
-    @DisplayName("조회수 증가 성공")
-    void incrementViewCount() {
+    @DisplayName("스케줄러 조회수 동기화 성공")
+    void updateViewCount() {
         // given
         Match match = Match.builder()
                 .matchName("LCK")
@@ -40,15 +40,20 @@ public class MatchRepositoryTest {
                 .startTime(LocalDateTime.now().plusDays(1))
                 .build();
         matchRepository.save(match);
+        // 초기 조회수는 0L
+        assertThat(match.getViewCount()).isEqualTo(0L);
+
+        Long newViewCount = 12345L;
 
         // when
-        matchRepository.incrementViewCount(match.getId());
+        // MatchService가 호출할 동기화 쿼리 실행
+        matchRepository.updateViewCount(match.getId(), newViewCount);
         entityManager.flush();
         entityManager.clear();
 
         // then
         Match updatedMatch = matchRepository.findById(match.getId()).orElseThrow();
-        assertThat(updatedMatch.getViewCount()).isEqualTo(1L);
+        assertThat(updatedMatch.getViewCount()).isEqualTo(newViewCount); // 12345L
     }
 
     @Test

--- a/src/test/java/org/example/oddventure/domain/match/unit/MatchServiceCacheTest.java
+++ b/src/test/java/org/example/oddventure/domain/match/unit/MatchServiceCacheTest.java
@@ -1,0 +1,83 @@
+package org.example.oddventure.domain.match.unit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import java.time.LocalDateTime;
+import org.example.oddventure.base.RedisTestContainerConfig;
+import org.example.oddventure.domain.match.entity.Match;
+import org.example.oddventure.domain.match.repository.MatchRepository;
+import org.example.oddventure.domain.match.service.MatchService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.util.StopWatch;
+
+@SpringBootTest
+@ActiveProfiles("test")
+public class MatchServiceCacheTest extends RedisTestContainerConfig {
+
+    @Autowired
+    private MatchService matchService;
+
+    @Autowired
+    private MatchRepository matchRepository;
+
+    @Autowired
+    private RedisTemplate<String, Object> redisTemplate;
+
+    private Match finishedMatch;
+
+    @BeforeEach
+    void setUp() {
+        redisTemplate.getConnectionFactory().getConnection().flushAll();
+
+        // 1. 'FINISHED' 상태의 매치 생성
+        Match match1 = Match.builder()
+                .matchName("Finished Match")
+                .teamA("T1")
+                .teamB("GEN.G")
+                .startTime(LocalDateTime.now().minusDays(1))
+                .build();
+
+        match1.finishMatch("T1", "GEN.G");
+        finishedMatch = matchRepository.save(match1);
+    }
+
+    @AfterEach
+    void tearDown() {
+        matchRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("종료된 경기 상세 조회 캐싱 적용 전/후 성능 비교 (StopWatch)")
+    void testFinishedMatchCachePerformance() {
+        // given
+        Long finishedMatchId = finishedMatch.getId();
+        StopWatch stopWatch = new StopWatch("FinishedMatch Cache Performance");
+
+        // when
+        // 1. "캐싱 적용 전" (Cache Miss)
+        stopWatch.start("Cache Miss (DB)");
+        matchService.getMatch(finishedMatchId);
+        stopWatch.stop();
+
+        // when
+        // 2. "캐싱 적용 후" (Cache Hit)
+        stopWatch.start("Cache Hit (Redis)");
+        matchService.getMatch(finishedMatchId);
+        stopWatch.stop();
+
+        // then
+        // 3. 결과 출력
+        System.out.println(stopWatch.prettyPrint());
+        long missTime = stopWatch.getTaskInfo()[0].getTimeMillis();
+        long hitTime = stopWatch.getTaskInfo()[1].getTimeMillis();
+
+        // 4. 검증
+        assertThat(hitTime).isLessThan(missTime);
+    }
+}

--- a/src/test/java/org/example/oddventure/domain/match/unit/MatchServiceTest.java
+++ b/src/test/java/org/example/oddventure/domain/match/unit/MatchServiceTest.java
@@ -225,7 +225,6 @@ class MatchServiceTest {
             // then
             assertThat(result).isNotNull();
             assertThat(result.teamA()).isEqualTo("T1");
-            verify(matchRepository, never()).incrementViewCount(anyLong()); // DB UPDATE가 호출되지 않아야 함
             verify(matchRepository).findById(matchId); // DB SELECT만 호출됨
         }
 
@@ -260,7 +259,6 @@ class MatchServiceTest {
             matchService.incrementViewCount(matchId);
 
             // then
-            verify(matchRepository, never()).incrementViewCount(anyLong());
             verify(matchRepository, never()).existsById(anyLong());
 
             // Redis INCR이 1번 호출되었는지 검증

--- a/src/test/java/org/example/oddventure/domain/match/unit/MatchServiceTest.java
+++ b/src/test/java/org/example/oddventure/domain/match/unit/MatchServiceTest.java
@@ -3,8 +3,10 @@ package org.example.oddventure.domain.match.unit;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -40,6 +42,8 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
 
 @ExtendWith(MockitoExtension.class)
 class MatchServiceTest {
@@ -56,22 +60,24 @@ class MatchServiceTest {
     @Mock
     private HotKeywordsService hotKeywordsService;
 
+    @Mock
+    private RedisTemplate<String, Object> redisTemplate;
+
+    @Mock
+    private ValueOperations<String, Object> valueOperations;
+
     @Test
     @DisplayName("매치 생성 성공")
     void createMatch_Success() {
         // given
         LocalDateTime startTime = LocalDateTime.now().plusDays(1);
         MatchScheduleDto request = new MatchScheduleDto(1L, "LCK", "T1", "Gen.G", startTime);
-
         Match match = Match.builder().teamA("T1").teamB("Gen.G").startTime(startTime).build();
-
         given(matchRepository.save(any(Match.class))).willReturn(match);
         doNothing().when(matchEventProducer)
                 .produceMatchStartEvent(MatchStartEventDto.from(match.getId(), match.getStartTime()));
-
         // when
         MatchCreateDto response = matchService.createMatch(request);
-
         // then
         assertThat(response.fetchId()).isEqualTo(1L);
         verify(matchRepository).save(any(Match.class));
@@ -197,8 +203,8 @@ class MatchServiceTest {
     }
 
     @Nested
-    @DisplayName("경기 상세 조회")
-    class getMatch {
+    @DisplayName("경기 상세 조회 (캐시 적용)")
+    class GetMatch {
         @Test
         @DisplayName("경기 상세 조회 성공")
         void getMatch_success() {
@@ -211,7 +217,6 @@ class MatchServiceTest {
                     .startTime(LocalDateTime.now().plusDays(1))
                     .build();
 
-            when(matchRepository.incrementViewCount(matchId)).thenReturn(1);
             when(matchRepository.findById(matchId)).thenReturn(Optional.of(match));
 
             // when
@@ -220,29 +225,15 @@ class MatchServiceTest {
             // then
             assertThat(result).isNotNull();
             assertThat(result.teamA()).isEqualTo("T1");
-            assertThat(result.startTime()).isEqualTo(match.getStartTime());
+            verify(matchRepository, never()).incrementViewCount(anyLong()); // DB UPDATE가 호출되지 않아야 함
+            verify(matchRepository).findById(matchId); // DB SELECT만 호출됨
         }
 
         @Test
-        @DisplayName("경기 상세 조회 실패 - 조회수 증가 실패 시 MatchException 발생")
-        void getMatch_fail_incrementViewCount() {
-            // given
-            Long matchId = 1L;
-            when(matchRepository.incrementViewCount(matchId)).thenReturn(0);
-
-            // when
-            MatchException exception = assertThrows(MatchException.class, () -> matchService.getMatch(matchId));
-
-            // then
-            assertThat(exception.getMessage()).isEqualTo(MatchErrorCode.MATCH_NOT_FOUND.getMessage());
-        }
-
-        @Test
-        @DisplayName("경기 상세 조회 실패 - increment 성공 후 findById에서 MatchException 발생")
+        @DisplayName("경기 상세 조회 실패 - findById 실패 시 MatchException 발생")
         void getMatch_fail_findById() {
             // given
             Long matchId = 1L;
-            when(matchRepository.incrementViewCount(matchId)).thenReturn(1);
             when(matchRepository.findById(matchId)).thenReturn(Optional.empty());
 
             // when
@@ -251,28 +242,86 @@ class MatchServiceTest {
             // then
             assertThat(exception.getMessage()).isEqualTo(MatchErrorCode.MATCH_NOT_FOUND.getMessage());
         }
+    }
+
+    @Nested
+    @DisplayName("조회수 증가 (Redis INCR)")
+    class IncrementViewCount {
+        @Test
+        @DisplayName("조회수 증가 성공 - Redis INCR 호출")
+        void incrementViewCount_success() {
+            // given
+            Long matchId = 1L;
+            String expectedKey = "match:viewcount:" + matchId;
+            given(redisTemplate.opsForValue()).willReturn(valueOperations);
+            given(valueOperations.increment(expectedKey)).willReturn(1L);
+
+            // when
+            matchService.incrementViewCount(matchId);
+
+            // then
+            verify(matchRepository, never()).incrementViewCount(anyLong());
+            verify(matchRepository, never()).existsById(anyLong());
+
+            // Redis INCR이 1번 호출되었는지 검증
+            verify(redisTemplate.opsForValue()).increment(expectedKey);
+        }
+    }
+
+    @Nested
+    @DisplayName("조회수 DB 동기화 (Scheduler)")
+    class UpdateViewCount {
+        @Test
+        @DisplayName("조회수 DB 동기화 성공")
+        void updateViewCount_success() {
+            // given
+            Long matchId = 1L;
+            Long viewCount = 120L;
+            given(matchRepository.updateViewCount(matchId, viewCount)).willReturn(1);
+
+            // when
+            matchService.updateViewCount(matchId, viewCount);
+
+            // then
+            verify(matchRepository).updateViewCount(matchId, viewCount);
+        }
 
         @Test
-        @DisplayName("매치 상태값 변경 성공")
-        void updateStatus_success() {
-            //given
-            Long matchId = 1L;
-            MatchStatus status = MatchStatus.ONGOING;
+        @DisplayName("조회수 DB 동기화 - 대상 없음 (WARN 로그)")
+        void updateViewCount_fail_notFound() {
+            // given
+            Long matchId = 999L;
+            Long viewCount = 120L;
+            given(matchRepository.updateViewCount(matchId, viewCount)).willReturn(0);
 
-            Match match = Match.builder()
-                    .matchName("LCK")
-                    .teamA("T1")
-                    .teamB("GEN.G")
-                    .startTime(LocalDateTime.now().plusDays(1))
-                    .build();
+            // when
+            matchService.updateViewCount(matchId, viewCount);
 
-            when(matchRepository.findById(matchId)).thenReturn(Optional.of(match));
-
-            //when
-            matchService.updateStatus(matchId, status);
-
-            //then
-            assertThat(match.getStatus()).isEqualTo(status);
+            // then
+            verify(matchRepository).updateViewCount(matchId, viewCount);
         }
+    }
+
+    @Test
+    @DisplayName("매치 상태값 변경 성공")
+    void updateStatus_success() {
+        //given
+        Long matchId = 1L;
+        MatchStatus status = MatchStatus.ONGOING;
+
+        Match match = Match.builder()
+                .matchName("LCK")
+                .teamA("T1")
+                .teamB("GEN.G")
+                .startTime(LocalDateTime.now().plusDays(1))
+                .build();
+
+        when(matchRepository.findById(matchId)).thenReturn(Optional.of(match));
+
+        //when
+        matchService.updateStatus(matchId, status);
+
+        //then
+        assertThat(match.getStatus()).isEqualTo(status);
     }
 }

--- a/src/test/java/org/example/oddventure/domain/team/unit/TeamServiceCacheTest.java
+++ b/src/test/java/org/example/oddventure/domain/team/unit/TeamServiceCacheTest.java
@@ -1,0 +1,67 @@
+package org.example.oddventure.domain.team.unit;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import org.example.oddventure.base.RedisTestContainerConfig;
+import org.example.oddventure.domain.team.entity.Team;
+import org.example.oddventure.domain.team.repository.TeamRepository;
+import org.example.oddventure.domain.team.service.TeamService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.util.StopWatch;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class TeamServiceCacheTest extends RedisTestContainerConfig {
+
+    @Autowired
+    private TeamService teamService;
+
+    @Autowired
+    private TeamRepository teamRepository;
+
+    @Autowired
+    private RedisTemplate<String, Object> redisTemplate;
+
+    @BeforeEach
+    void setUp() {
+        // 캐시 비우기
+        redisTemplate.getConnectionFactory().getConnection().flushAll();
+
+        // 테스트 데이터 1개 삽입
+        if (teamRepository.count() == 0) {
+            teamRepository.save(Team.builder().name("T1").build());
+        }
+    }
+
+    @Test
+    @DisplayName("팀 상세 조회 캐싱 적용 전/후 성능 비교")
+    void testTeamDetailCachePerformance() {
+
+        Long teamId = 1L;
+        StopWatch stopWatch = new StopWatch();
+
+        // 1. "캐싱 적용 전" 측정 (캐시 MISS)
+        stopWatch.start("Cache Miss");
+        teamService.getTeamById(teamId); // 처음 호출 (DB 조회 + 캐시 저장)
+        stopWatch.stop();
+
+        // 2. "캐싱 적용 후" 측정 (캐시 HIT)
+        stopWatch.start("Cache Hit");
+        teamService.getTeamById(teamId); // 두 번째 호출 (Redis에서 조회)
+        stopWatch.stop();
+
+        // 3. 결과 출력
+        System.out.println(stopWatch.prettyPrint());
+        long firstCallTime = stopWatch.getTaskInfo()[0].getTimeMillis();
+        long secondCallTime = stopWatch.getTaskInfo()[1].getTimeMillis();
+
+        // 4. 검증
+        assertThat(firstCallTime).isGreaterThan(secondCallTime);
+    }
+}

--- a/src/test/java/org/example/oddventure/domain/user/unit/UserServiceConcurrencyTest.java
+++ b/src/test/java/org/example/oddventure/domain/user/unit/UserServiceConcurrencyTest.java
@@ -1,0 +1,98 @@
+package org.example.oddventure.domain.user.unit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import java.math.BigDecimal;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.example.oddventure.domain.admin.dto.request.PointAdjustRequest;
+import org.example.oddventure.domain.user.entity.User;
+import org.example.oddventure.domain.user.repository.UserRepository;
+import org.example.oddventure.domain.user.service.UserService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+/**
+ * [동시성 테스트] UserService의 포인트 지급 로직 동시성 테스트
+ * 비관적 락(@Lock(PESSIMISTIC_WRITE))이 데이터 정합성을 보장하는지 검증
+ */
+@SpringBootTest
+public class UserServiceConcurrencyTest {
+
+    @Autowired
+    private UserService userService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private User testUser;
+
+    /**
+     * 테스트 실행 전, 동시성 테스트에 사용할 사용자를 생성하고
+     * 초기 포인트를 0으로 설정
+     */
+    @BeforeEach
+    void setUp() {
+        User user = User.builder()
+                .username("concurrentUser")
+                .email("concurrent@test.com")
+                .password("password")
+                .build();
+
+        // 테스트 전 초기 포인트 0으로 설정
+        // (User 생성자는 기본 1000 포인트를 가지므로 1000을 차감)
+        user.minusPoint(new BigDecimal("1000"));
+        testUser = userRepository.saveAndFlush(user);
+
+        assertThat(testUser.getPoint()).isEqualByComparingTo(BigDecimal.ZERO);
+    }
+
+    /**
+     * 테스트 실행 후, 생성된 사용자를 삭제
+     */
+    @AfterEach
+    void tearDown() {
+        userRepository.deleteById(testUser.getId());
+    }
+
+    /**
+     * 100개의 스레드가 동시에 10포인트씩 지급을 요청할 때,
+     * Lost Update 없이 총 1000 포인트가 정확히 적립되는지 테스트
+     */
+    @Test
+    @DisplayName("동시에 100명이 10포인트씩 지급 요청 시 1000포인트가 정확히 적립된다 (비관적 락)")
+    void adjustUserPoints_ConcurrencyTest_Success() throws InterruptedException {
+        // given
+        int threadCount = 100;
+        BigDecimal pointToAdd = BigDecimal.TEN;
+        BigDecimal expectedResult = pointToAdd.multiply(BigDecimal.valueOf(threadCount));
+        ExecutorService executorService = Executors.newFixedThreadPool(32);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        PointAdjustRequest request = new PointAdjustRequest(pointToAdd, "동시성 테스트");
+
+        // when
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    userService.adjustUserPoints(testUser.getId(), request);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+        executorService.shutdown();
+
+        // then
+        // DB에서 최종 사용자 정보를 다시 조회
+        User updatedUser = userRepository.findById(testUser.getId()).orElseThrow();
+
+        // 비관적 락으로 인해 "Lost Update"가 발생하지 않아 정확히 1000 포인트가 되어야 함
+        assertThat(updatedUser.getPoint()).isEqualByComparingTo(expectedResult);
+    }
+}

--- a/src/test/java/org/example/oddventure/domain/user/unit/UserServiceConcurrencyTest.java
+++ b/src/test/java/org/example/oddventure/domain/user/unit/UserServiceConcurrencyTest.java
@@ -5,6 +5,7 @@ import java.math.BigDecimal;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import org.example.oddventure.base.RedisTestContainerConfig;
 import org.example.oddventure.domain.admin.dto.request.PointAdjustRequest;
 import org.example.oddventure.domain.user.entity.User;
 import org.example.oddventure.domain.user.repository.UserRepository;
@@ -15,13 +16,11 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
-/**
- * [동시성 테스트] UserService의 포인트 지급 로직 동시성 테스트
- * 비관적 락(@Lock(PESSIMISTIC_WRITE))이 데이터 정합성을 보장하는지 검증
- */
 @SpringBootTest
-public class UserServiceConcurrencyTest {
+@ActiveProfiles("test")
+public class UserServiceConcurrencyTest extends RedisTestContainerConfig {
 
     @Autowired
     private UserService userService;
@@ -64,7 +63,7 @@ public class UserServiceConcurrencyTest {
      * Lost Update 없이 총 1000 포인트가 정확히 적립되는지 테스트
      */
     @Test
-    @DisplayName("동시에 100명이 10포인트씩 지급 요청 시 1000포인트가 정확히 적립된다 (비관적 락)")
+    @DisplayName("동시에 100명이 10포인트씩 지급 요청 시 1000포인트가 정확히 적립된다 (분산 락)")
     void adjustUserPoints_ConcurrencyTest_Success() throws InterruptedException {
         // given
         int threadCount = 100;
@@ -89,10 +88,8 @@ public class UserServiceConcurrencyTest {
         executorService.shutdown();
 
         // then
-        // DB에서 최종 사용자 정보를 다시 조회
         User updatedUser = userRepository.findById(testUser.getId()).orElseThrow();
 
-        // 비관적 락으로 인해 "Lost Update"가 발생하지 않아 정확히 1000 포인트가 되어야 함
         assertThat(updatedUser.getPoint()).isEqualByComparingTo(expectedResult);
     }
 }

--- a/src/test/java/org/example/oddventure/domain/user/unit/UserServiceTest.java
+++ b/src/test/java/org/example/oddventure/domain/user/unit/UserServiceTest.java
@@ -9,9 +9,13 @@ import static org.mockito.Mockito.verify;
 
 import java.math.BigDecimal;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import org.example.oddventure.common.exception.GlobalException;
 import org.example.oddventure.domain.admin.dto.request.PointAdjustRequest;
 import org.example.oddventure.domain.admin.dto.response.PointAdjustResponse;
+import org.example.oddventure.domain.admin.exception.AdminErrorCode;
+import org.example.oddventure.domain.bet.exception.BetErrorCode;
+import org.example.oddventure.domain.bet.exception.BetException;
 import org.example.oddventure.domain.user.dto.request.PasswordUpdateRequest;
 import org.example.oddventure.domain.user.dto.request.ProfileUpdateRequest;
 import org.example.oddventure.domain.user.dto.response.UserProfileResponse;
@@ -20,6 +24,7 @@ import org.example.oddventure.domain.user.exception.UserErrorCode;
 import org.example.oddventure.domain.user.exception.UserException;
 import org.example.oddventure.domain.user.repository.UserRepository;
 import org.example.oddventure.domain.user.service.UserService;
+import org.example.oddventure.domain.user.service.UserPointTransactionService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -27,6 +32,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 @ExtendWith(MockitoExtension.class)
@@ -40,6 +47,15 @@ class UserServiceTest {
 
     @Mock
     private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private RedissonClient redissonClient;
+
+    @Mock
+    private UserPointTransactionService userPointTransactionService;
+
+    @Mock
+    private RLock lock;
 
     @Test
     @DisplayName("사용자 프로필 조회 성공")
@@ -145,42 +161,32 @@ class UserServiceTest {
         verify(passwordEncoder).encode("newPassword123!");
     }
 
-    @Test
-    @DisplayName("비밀번호 변경 실패 - 현재 비밀번호 불일치")
-    void updatePassword_fail_passwordIncorrect() {
-        // given
-        Long userId = 1L;
-        PasswordUpdateRequest request = new PasswordUpdateRequest("wrongPassword!", "newPassword123!");
-        User mockUser = User.builder().password("encodedCurrentPassword").build();
-
-        given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));
-        given(passwordEncoder.matches("wrongPassword!", "encodedCurrentPassword")).willReturn(false);
-
-        // when & then
-        assertThrows(UserException.class, () -> {
-            userService.updatePassword(userId, request);
-        });
-    }
-
     @Nested
     @DisplayName("사용자 포인트 지급")
     class adjustUserPoint {
         @Test
-        @DisplayName("사용자 포인트 지급 성공")
-        void adjustUserPoints_Success() {
+        @DisplayName("사용자 포인트 지급 성공 (분산 락)")
+        void adjustUserPoints_Success() throws InterruptedException {
             // given
             Long userId = 1L;
             BigDecimal amountToAdd = new BigDecimal("5000");
             PointAdjustRequest request = new PointAdjustRequest(amountToAdd, "베팅 승리 보상");
 
-            // User 엔티티 생성 시 Builder는 point를 1000으로 초기화(초기 지급 포인트)
             User mockUser = User.builder()
                     .email("test@test.com")
                     .username("testuser")
                     .password("password")
                     .build();
+            // User 엔티티는 1000포인트로 시작
+            mockUser.plusPoint(amountToAdd); // 6000 포인트가 된 유저 Mock
 
-            given(userRepository.findByIdForUpdate(userId)).willReturn(Optional.of(mockUser));
+            // Redisson 락 Mocking
+            given(redissonClient.getLock(any(String.class))).willReturn(lock);
+            given(lock.tryLock(10, 5, TimeUnit.SECONDS)).willReturn(true); // 락 획득 성공
+
+            // 트랜잭션 서비스 Mocking
+            given(userPointTransactionService.increaseUserPoint(userId, request))
+                    .willReturn(mockUser); // 6000 포인트 유저 반환
 
             // when
             PointAdjustResponse response = userService.adjustUserPoints(userId, request);
@@ -188,17 +194,39 @@ class UserServiceTest {
             // then
             assertThat(response.userId()).isEqualTo(mockUser.getId());
             assertThat(response.adjustedAmount()).isEqualTo(amountToAdd);
-            assertThat(response.finalBalance()).isEqualTo(new BigDecimal("6000"));
-            assertThat(mockUser.getPoint()).isEqualTo(new BigDecimal("6000"));
+            assertThat(response.finalBalance()).isEqualTo(new BigDecimal("6000")); // 1000 + 5000
         }
 
         @Test
-        @DisplayName("사용자 포인트 지급 실패 - 존재하지 않는 사용자")
-        void adjustUserPoints_Fail_UserNotFound() {
+        @DisplayName("사용자 포인트 지급 실패 - 락 획득 실패")
+        void adjustUserPoints_Fail_LockFailed() throws InterruptedException {
+            // given
+            Long userId = 1L;
+            PointAdjustRequest request = new PointAdjustRequest(BigDecimal.TEN, "이벤트 보상");
+
+            given(redissonClient.getLock(any(String.class))).willReturn(lock);
+            given(lock.tryLock(10, 5, TimeUnit.SECONDS)).willReturn(false); // 락 획득 실패
+
+            // when & then
+            BetException exception = assertThrows(BetException.class, () -> {
+                userService.adjustUserPoints(userId, request);
+            });
+            assertThat(exception.getErrorCode()).isEqualTo(BetErrorCode.BET_LOCK_FAILED);
+        }
+
+        @Test
+        @DisplayName("사용자 포인트 지급 실패 - 트랜잭션 중 예외 발생")
+        void adjustUserPoints_Fail_UserNotFoundInTransaction() throws InterruptedException {
             // given
             Long userId = 999L;
-            PointAdjustRequest request = new PointAdjustRequest(new BigDecimal("5000"), "이벤트 보상");
-            given(userRepository.findByIdForUpdate(userId)).willReturn(Optional.empty());
+            PointAdjustRequest request = new PointAdjustRequest(BigDecimal.TEN, "이벤트 보상");
+
+            given(redissonClient.getLock(any(String.class))).willReturn(lock);
+            given(lock.tryLock(10, 5, TimeUnit.SECONDS)).willReturn(true); // 락 획득 성공
+
+            // 트랜잭션 서비스에서 예외 발생
+            given(userPointTransactionService.increaseUserPoint(userId, request))
+                    .willThrow(new GlobalException(AdminErrorCode.USER_NOT_FOUND));
 
             // when & then
             assertThrows(GlobalException.class, () -> {

--- a/src/test/java/org/example/oddventure/domain/user/unit/UserServiceTest.java
+++ b/src/test/java/org/example/oddventure/domain/user/unit/UserServiceTest.java
@@ -180,7 +180,7 @@ class UserServiceTest {
                     .password("password")
                     .build();
 
-            given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));
+            given(userRepository.findByIdForUpdate(userId)).willReturn(Optional.of(mockUser));
 
             // when
             PointAdjustResponse response = userService.adjustUserPoints(userId, request);
@@ -198,7 +198,7 @@ class UserServiceTest {
             // given
             Long userId = 999L;
             PointAdjustRequest request = new PointAdjustRequest(new BigDecimal("5000"), "이벤트 보상");
-            given(userRepository.findById(userId)).willReturn(Optional.empty());
+            given(userRepository.findByIdForUpdate(userId)).willReturn(Optional.empty());
 
             // when & then
             assertThrows(GlobalException.class, () -> {


### PR DESCRIPTION
## 📝 작업 내용
1. 동시성 제어 (비관적 락 ➔ 분산 락)
- BetService, UserService의 동시성 제어 방식 변경
- (Before) findByIdForUpdate (JPA 비관적 락)
- (After) RedissonClient (RLock, RMultiLock)을 이용한 Redisson 분산 락 적용


2. 캐싱 및 조회 성능

2-1) TeamService 캐싱 적용
- getAllTeam (팀 목록), getTeamById (팀 상세)에 @Cacheable 적용

2-2) MatchService.getMatch 캐싱 적용

- (1단계 기존 코드) 원본 코드는 DB UPDATE + SELECT가 섞여있어 캐싱 불가 및 DB 병목 발생

- (2단계 로직 분리) MatchController가 incrementViewCount(Write)와 getMatch(Read)를 순차 호출하도록 CQRS 패턴 적용

- (3단계 캐싱 적용) getMatch 메서드에 @Cacheable을 적용하여 SELECT 병목 해결

- (4단계 병목 해결) incrementViewCount가 DB UPDATE가 아닌 Redis INCR을 사용하도록 변경하여, k6 테스트에서 발생한 i/o timeout (DB Row Lock 경합) 문제를 최종 해결

2-3) MatchScheduler 추가

- 4단계 고도화에 따라, 5분마다 Redis의 match:viewcount:* 데이터를 RDB에 동기화하는 syncViewCountsToDB 스케줄러 추가





## 🔗 연관된 이슈
<!---- Related to: #(Isuue Number) -->
- #68 


## ✅ PR 유형

- [x] 새로운 기능 추가
- [x] 코드 리팩토링
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정 및 삭제
- [ ] 그 외
