### PR TITLE
feat: 매치 결과 업데이트

### DIFF
--- a/src/main/java/org/example/oddventure/OddventureApplication.java
+++ b/src/main/java/org/example/oddventure/OddventureApplication.java
@@ -2,7 +2,9 @@ package org.example.oddventure;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class OddventureApplication {
 

--- a/src/main/java/org/example/oddventure/domain/admin/exception/AdminErrorCode.java
+++ b/src/main/java/org/example/oddventure/domain/admin/exception/AdminErrorCode.java
@@ -9,7 +9,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum AdminErrorCode implements ErrorCode {
 
-    MATCH_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 경기를 찾을 수 없습니다."),
+    MATCH_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 매치를 찾을 수 없습니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 사용자를 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/org/example/oddventure/domain/bet/exception/BetErrorCode.java
+++ b/src/main/java/org/example/oddventure/domain/bet/exception/BetErrorCode.java
@@ -9,9 +9,10 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum BetErrorCode implements ErrorCode {
 
+    MATCH_NOT_EXIST(HttpStatus.NOT_FOUND, "존재하지 않는 매치입니다."),
     NOT_ENOUGH_POINTS(HttpStatus.BAD_REQUEST, "보유 포인트가 부족합니다."),
-    MATCH_NOT_BETTABLE(HttpStatus.BAD_REQUEST, "베팅이 마감되었거나 진행 중인 경기입니다."),
-    MATCH_NOT_CANCELABLE(HttpStatus.BAD_REQUEST, "취소가 불가능한 경기입니다."),
+    MATCH_NOT_BETTABLE(HttpStatus.BAD_REQUEST, "베팅이 마감되었거나 진행 중인 매치입니다."),
+    MATCH_NOT_CANCELABLE(HttpStatus.BAD_REQUEST, "취소가 불가능한 매치입니다."),
     ODDS_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 베팅 항목입니다."),
     BET_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 베팅 내역입니다."),
     PERMISSION_DENIED(HttpStatus.FORBIDDEN, "베팅을 취소할 권한이 없습니다.");

--- a/src/main/java/org/example/oddventure/domain/bet/service/BetService.java
+++ b/src/main/java/org/example/oddventure/domain/bet/service/BetService.java
@@ -49,7 +49,7 @@ public class BetService {
                 .orElseThrow(() -> new MatchException(MatchErrorCode.MATCH_NOT_FOUND));
 
         // 베팅 가능 여부 검증
-        validateBettable(match.getStatus());
+        validateBettable(match);
 
         // 유저 포인트 차감
         user.minusPoint(betAmount);
@@ -106,8 +106,12 @@ public class BetService {
                 .orElseThrow(() -> new UserException(UserErrorCode.INVALID_USER_ID));
     }
 
-    private void validateBettable(MatchStatus status) {
-        if (!status.equals(MatchStatus.SCHEDULED)) {
+    private void validateBettable(Match match) {
+        if (match.isDeleted()) {
+            throw new BetException(BetErrorCode.MATCH_NOT_EXIST);
+        }
+
+        if (!match.getStatus().equals(MatchStatus.SCHEDULED)) {
             throw new BetException(BetErrorCode.MATCH_NOT_BETTABLE);
         }
     }

--- a/src/main/java/org/example/oddventure/domain/grid/dto/MatchResultDto.java
+++ b/src/main/java/org/example/oddventure/domain/grid/dto/MatchResultDto.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 @Builder
 public record MatchResultDto(
         Long fetchId,
+        boolean finished,
         String winner,
         String loser
 ) {

--- a/src/main/java/org/example/oddventure/domain/grid/dto/response/field/SeriesState.java
+++ b/src/main/java/org/example/oddventure/domain/grid/dto/response/field/SeriesState.java
@@ -3,6 +3,7 @@ package org.example.oddventure.domain.grid.dto.response.field;
 import java.util.List;
 
 public record SeriesState(
+        boolean finished,
         List<Team> teams
 ) {
     public record Team(

--- a/src/main/java/org/example/oddventure/domain/grid/service/GridService.java
+++ b/src/main/java/org/example/oddventure/domain/grid/service/GridService.java
@@ -19,6 +19,7 @@ import org.example.oddventure.domain.grid.dto.response.SeriesStateResponse;
 import org.example.oddventure.domain.grid.dto.response.field.Edge;
 import org.example.oddventure.domain.grid.dto.response.field.Node;
 import org.example.oddventure.domain.grid.dto.response.field.PageInfo;
+import org.example.oddventure.domain.grid.dto.response.field.SeriesState;
 import org.example.oddventure.domain.grid.dto.response.field.SeriesState.Team;
 import org.example.oddventure.domain.grid.exception.GridErrorCode;
 import org.example.oddventure.domain.grid.exception.GridException;
@@ -81,6 +82,8 @@ public class GridService {
     private static final String GRID_LIVE_DATA_QUERY = """
             query GetLiveCS2SeriesState ($id: ID!){
                seriesState(id: $id) {
+                 valid
+                 finished
                  teams {
                    name
                    won
@@ -183,7 +186,11 @@ public class GridService {
             throw new GridException(GridErrorCode.RESPONSE_NOT_FOUND);
         }
 
-        List<Team> teams = response.data().seriesState().teams();
+        SeriesState seriesState = response.data().seriesState();
+
+        boolean finished = seriesState.finished();
+
+        List<Team> teams = seriesState.teams();
 
         String winner = teams.stream()
                 .filter(Team::won)
@@ -199,6 +206,7 @@ public class GridService {
 
         return MatchResultDto.builder()
                 .fetchId(fetchId)
+                .finished(finished)
                 .winner(winner)
                 .loser(loser)
                 .build();

--- a/src/main/java/org/example/oddventure/domain/match/repository/MatchRepository.java
+++ b/src/main/java/org/example/oddventure/domain/match/repository/MatchRepository.java
@@ -1,9 +1,11 @@
 package org.example.oddventure.domain.match.repository;
 
 import jakarta.persistence.LockModeType;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.example.oddventure.domain.match.entity.Match;
+import org.example.oddventure.domain.match.enums.MatchStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
@@ -29,4 +31,14 @@ public interface MatchRepository extends JpaRepository<Match, Long>, MatchReposi
     boolean existsByFetchId(Long fetchId);
 
     Optional<Match> findByFetchId(Long fetchId);
+
+    @Query("""
+            select m
+            from Match m
+            where m.status = :status
+            and m.startTime < CURRENT_TIMESTAMP
+            and m.startTime >= :twoDaysAgo
+            """)
+    List<Match> findByMatchStatus(@Param("status") MatchStatus matchStatus,
+                                  @Param("twoDaysAgo") LocalDateTime twoDaysAgo);
 }

--- a/src/main/java/org/example/oddventure/domain/match/scheduler/MatchScheduler.java
+++ b/src/main/java/org/example/oddventure/domain/match/scheduler/MatchScheduler.java
@@ -1,0 +1,53 @@
+package org.example.oddventure.domain.match.scheduler;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.oddventure.domain.grid.dto.MatchResultDto;
+import org.example.oddventure.domain.grid.service.GridService;
+import org.example.oddventure.domain.match.entity.Match;
+import org.example.oddventure.domain.match.enums.MatchStatus;
+import org.example.oddventure.domain.match.repository.MatchRepository;
+import org.example.oddventure.domain.match.service.MatchService;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MatchScheduler {
+
+    private final MatchRepository matchRepository;
+    private final MatchService matchService;
+    private final GridService gridService;
+
+    @Scheduled(cron = "0 0 13 * * *", zone = "Asia/Seoul")
+    public void autoFinishMatches() {
+        List<Match> matches = matchRepository.findByMatchStatus(
+                MatchStatus.ONGOING,
+                LocalDateTime.of(2025, 10, 25, 13, 0, 0));
+
+        matches.forEach(match -> {
+            if (match.isDeleted()) {
+                log.info("삭제된 매치입니다. matchId={}, fetchId={}", match.getId(), match.getFetchId());
+                return;
+            }
+
+            MatchResultDto result = gridService.fetchMatchResult(match.getFetchId());
+            handleResult(match, result);
+        });
+    }
+
+    private void handleResult(Match match, MatchResultDto result) {
+        if (result.finished()) {
+            matchService.updateMatchResult(
+                    match.getFetchId(),
+                    result.winner(),
+                    result.loser()
+            );
+        } else {
+            log.info("끝나지 않은 경기입니다. matchId={}, fetchId={}", match.getId(), match.getFetchId());
+        }
+    }
+}

--- a/src/main/java/org/example/oddventure/domain/match/service/MatchService.java
+++ b/src/main/java/org/example/oddventure/domain/match/service/MatchService.java
@@ -99,7 +99,7 @@ public class MatchService {
     }
 
     @Transactional
-    public void updateMatchResult(Long fetchId, String winner, String looser) {
+    public void updateMatchResult(Long fetchId, String winner, String loser) {
         Match match = matchRepository.findByFetchId(fetchId)
                 .orElseThrow(() -> new MatchException(MatchErrorCode.MATCH_NOT_FOUND));
 
@@ -107,7 +107,7 @@ public class MatchService {
             throw new MatchException(MatchErrorCode.MATCH_FINISHED);
         }
 
-        match.finishMatch(winner, looser);
+        match.finishMatch(winner, loser);
 
     }
 }

--- a/src/main/java/org/example/oddventure/domain/match/service/MatchService.java
+++ b/src/main/java/org/example/oddventure/domain/match/service/MatchService.java
@@ -3,10 +3,9 @@ package org.example.oddventure.domain.match.service;
 import static org.springframework.transaction.annotation.Propagation.REQUIRES_NEW;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.example.oddventure.domain.admin.dto.request.MatchUpdateRequest;
 import org.example.oddventure.domain.admin.dto.response.MatchUpdateAdminResponse;
-import org.example.oddventure.domain.admin.exception.AdminErrorCode;
-import org.example.oddventure.domain.admin.exception.AdminException;
 import org.example.oddventure.domain.grid.dto.MatchScheduleDto;
 import org.example.oddventure.domain.hotKeywords.service.HotKeywordsService;
 import org.example.oddventure.domain.match.dto.MatchCreateDto;
@@ -23,6 +22,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class MatchService {
@@ -57,7 +57,7 @@ public class MatchService {
     @Transactional
     public MatchUpdateAdminResponse updateMatch(Long matchId, MatchUpdateRequest request) {
         Match match = matchRepository.findById(matchId)
-                .orElseThrow(() -> new AdminException(AdminErrorCode.MATCH_NOT_FOUND));
+                .orElseThrow(() -> new MatchException(MatchErrorCode.MATCH_NOT_FOUND));
 
         match.update(
                 request.matchName(),

--- a/src/main/java/org/example/oddventure/domain/user/service/UserService.java
+++ b/src/main/java/org/example/oddventure/domain/user/service/UserService.java
@@ -4,8 +4,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.oddventure.domain.admin.dto.request.PointAdjustRequest;
 import org.example.oddventure.domain.admin.dto.response.PointAdjustResponse;
-import org.example.oddventure.domain.admin.exception.AdminErrorCode;
-import org.example.oddventure.domain.admin.exception.AdminException;
 import org.example.oddventure.domain.user.dto.request.PasswordUpdateRequest;
 import org.example.oddventure.domain.user.dto.request.ProfileUpdateRequest;
 import org.example.oddventure.domain.user.dto.response.UserProfileResponse;
@@ -62,8 +60,7 @@ public class UserService {
     // 포인트 지급
     @Transactional
     public PointAdjustResponse adjustUserPoints(Long userId, PointAdjustRequest request) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new AdminException(AdminErrorCode.USER_NOT_FOUND));
+        User user = findUserById(userId);
 
         user.plusPoint(request.amount());
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,31 @@
+spring:
+  config:
+    import: optional:file:.env[.properties]
+  datasource:
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+  jpa:
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+  data:
+    redis:
+      host: localhost
+      port: 6379
+  ai:
+    openai:
+      api-key: ${API_KEY}
+      base-url: ${BASE_URL}
+
+jwt:
+  secret:
+    key: "${SECRET_KEY}"
+
+grid:
+  central-data:
+    base-url: ${GRID_CENTRAL_BASE_URL}
+  live-data:
+    base-url: ${GRID_LIVE_BASE_URL}
+  api-key: ${GRID_API_KEY}


### PR DESCRIPTION
## 📝 작업 내용
<!---- 변경 사항 및 관련 이슈 예시
- 컨트롤러 API 수정
- Entity 생성자 추가
- 등등
-->
매치 일정이 자동으로 생성되면 매치가 끝나는 시점에 맞춰 결과 업데이트

**But**,

매치가 언제 끝나는지 정확하지 않고 관련 데이터를 제공 받을 수도 없다.

## 가정

- 경기 시작 후 2일 뒤면 매치가 다 끝날 것이다.
    - 보통 하루 뒤면 매치 끝난다.
    - 단, ex) 23시에 시작하는 매치일 경우 일수가 지나도 경기가 진행 중일 수 있다.
- 대부분 한국 기준 1시에 가장 경기가 없다.

## 결과

→ 48시간 전 매치 중 “Status = SECHEDULED”인 매치를 조회한다.

- 각 매치 요청 응답의 “finished = True”인 매치만 update한다.

<!---- 스크린샷 (선택) -->

## 🔗 연관된 이슈
- #58 
<!---- Related to: #(Isuue Number) -->

<!---- 리뷰 요구사항 (선택) -->

<!---- 현재 버그 (선택) -->

## ✅ PR 유형

- [x] 새로운 기능 추가
