### PR TITLE
feat: 진행중인 매치 상태값 업데이트

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-amqp'
 
     // lombok
     compileOnly 'org.projectlombok:lombok'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,8 @@ services:
       MYSQL_USER: ${MYSQL_USER}  # 추가 사용자 계정
       MYSQL_PASSWORD: ${MYSQL_PASSWORD}  # 추가 사용자 비밀번호
       TZ: Asia/Seoul  # 타임존 설정
+      RABBITMQ_DEFAULT_USER: ${RABBITMQ_USERNAME}
+      RABBITMQ_DEFAULT_PASS: ${RABBITMQ_PASSWORD}
 
     # 포트 매핑 (호스트:컨테이너)
     ports:
@@ -32,7 +34,7 @@ services:
 
     # 헬스체크 설정 (컨테이너 상태 모니터링)
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u${MYSQL_USER}", "-p${MYSQL_PASSWORD}"]
+      test: [ "CMD", "mysqladmin", "ping", "-h", "localhost", "-u${MYSQL_USER}", "-p${MYSQL_PASSWORD}" ]
       interval: 10s  # 10초마다 체크
       timeout: 5s  # 5초 타임아웃
       retries: 5  # 5회 실패 시 unhealthy 상태로 전환
@@ -60,7 +62,7 @@ services:
 
     # 헬스체크 설정
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]  # PING 명령으로 응답 확인
+      test: [ "CMD", "redis-cli", "ping" ]  # PING 명령으로 응답 확인
       interval: 10s
       timeout: 5s
       retries: 5
@@ -93,6 +95,17 @@ services:
     volumes:
       - grafana-storage:/var/lib/grafana # Grafana 데이터 디렉토리
 
+  # RabbitMQ 지연 처리 서비스
+  rabbitmq:
+    image: rabbitmq:4-management
+    container_name: oddventure-rabbitmq
+    restart: unless-stopped
+    ports:
+      - "5672:5672"
+      - "15672:15672" # GUI 웹 접속용 포트
+    volumes:
+      - rabbitmq_data:/var/lib/rabbitmq
+
 # 볼륨 정의 (데이터 영속성)
 volumes:
   mysql_data:
@@ -100,6 +113,8 @@ volumes:
   redis_data:
     driver: local
   grafana-storage: { } # Grafana 데이터 저장소 (대시보드/설정 영속화)
+  rabbitmq_data:
+    driver: local
 
 # 네트워크 정의 (컨테이너 간 통신)
 networks:

--- a/src/main/java/org/example/oddventure/common/config/RabbitMQConfig.java
+++ b/src/main/java/org/example/oddventure/common/config/RabbitMQConfig.java
@@ -14,6 +14,8 @@ public class RabbitMQConfig {
     public static final String DELAY_QUEUE = "match.delay.queue";
     public static final String DLX_EXCHANGE = "match.dlx.exchange";
     public static final String REAL_QUEUE = "match.real.queue";
+    public static final String DELAY_ROUTING_KEY = "match.delay";
+    public static final String REAL_ROUTING_KEY = "match.real";
 
     @Bean
     public DirectExchange delayExchange() {

--- a/src/main/java/org/example/oddventure/common/config/RabbitMQConfig.java
+++ b/src/main/java/org/example/oddventure/common/config/RabbitMQConfig.java
@@ -1,0 +1,50 @@
+package org.example.oddventure.common.config;
+
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.DirectExchange;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.QueueBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RabbitMQConfig {
+    public static final String DELAY_EXCHANGE = "match.delay.exchange";
+    public static final String DELAY_QUEUE = "match.delay.queue";
+    public static final String DLX_EXCHANGE = "match.dlx.exchange";
+    public static final String REAL_QUEUE = "match.real.queue";
+
+    @Bean
+    public DirectExchange delayExchange() {
+        return new DirectExchange(DELAY_EXCHANGE);
+    }
+
+    @Bean
+    public DirectExchange dlxExchange() {
+        return new DirectExchange(DLX_EXCHANGE);
+    }
+
+    @Bean
+    public DirectExchange realExchange() {
+        return new DirectExchange(REAL_QUEUE);
+    }
+
+    @Bean
+    public Queue delayQueue() {
+        return QueueBuilder.durable(DELAY_QUEUE)
+                .withArgument("x-dead-letter-exchange", DLX_EXCHANGE)
+                .withArgument("x-dead-letter-routing-key", "match.real")
+                .build();
+    }
+
+    @Bean
+    public Queue realQueue() {
+        return QueueBuilder.durable(REAL_QUEUE).build();
+    }
+
+    @Bean
+    public Binding delayBinding() {
+        return BindingBuilder.bind(delayQueue()).to(delayExchange()).with("match.delay");
+    }
+}

--- a/src/main/java/org/example/oddventure/common/config/RabbitMQConfig.java
+++ b/src/main/java/org/example/oddventure/common/config/RabbitMQConfig.java
@@ -5,6 +5,10 @@ import org.springframework.amqp.core.BindingBuilder;
 import org.springframework.amqp.core.DirectExchange;
 import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.core.QueueBuilder;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -28,15 +32,10 @@ public class RabbitMQConfig {
     }
 
     @Bean
-    public DirectExchange realExchange() {
-        return new DirectExchange(REAL_QUEUE);
-    }
-
-    @Bean
     public Queue delayQueue() {
         return QueueBuilder.durable(DELAY_QUEUE)
                 .withArgument("x-dead-letter-exchange", DLX_EXCHANGE)
-                .withArgument("x-dead-letter-routing-key", "match.real")
+                .withArgument("x-dead-letter-routing-key", REAL_ROUTING_KEY)
                 .build();
     }
 
@@ -48,5 +47,24 @@ public class RabbitMQConfig {
     @Bean
     public Binding delayBinding() {
         return BindingBuilder.bind(delayQueue()).to(delayExchange()).with("match.delay");
+    }
+
+    @Bean
+    public Binding realBinding() {
+        return BindingBuilder.bind(realQueue())
+                .to(dlxExchange())
+                .with(REAL_ROUTING_KEY);
+    }
+
+    @Bean
+    public MessageConverter jsonMessageConverter() {
+        return new Jackson2JsonMessageConverter();
+    }
+
+    @Bean
+    public RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory) {
+        RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory);
+        rabbitTemplate.setMessageConverter(jsonMessageConverter());
+        return rabbitTemplate;
     }
 }

--- a/src/main/java/org/example/oddventure/domain/grid/service/GridService.java
+++ b/src/main/java/org/example/oddventure/domain/grid/service/GridService.java
@@ -38,8 +38,8 @@ public class GridService {
                 filter:{
                   titleId: "28" # CS2
                   startTimeScheduled:{
-                    gte: "2025-10-24T15:00:07+02:00"
-                    lte: "2025-10-25T15:00:07+02:00"
+                    gte: "2025-11-03T15:00:07+02:00"
+                    lte: "2025-11-04T15:00:07+02:00"
                   }
                 }
                 orderBy: StartTimeScheduled

--- a/src/main/java/org/example/oddventure/domain/match/dto/event/MatchStartEventDto.java
+++ b/src/main/java/org/example/oddventure/domain/match/dto/event/MatchStartEventDto.java
@@ -1,0 +1,17 @@
+package org.example.oddventure.domain.match.dto.event;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+@Builder
+public record MatchStartEventDto(
+        Long matchId,
+        LocalDateTime StartTime
+) {
+    public static MatchStartEventDto from(Long matchId, LocalDateTime StartTime) {
+        return MatchStartEventDto.builder()
+                .matchId(matchId)
+                .StartTime(StartTime)
+                .build();
+    }
+}

--- a/src/main/java/org/example/oddventure/domain/match/dto/event/MatchStartEventDto.java
+++ b/src/main/java/org/example/oddventure/domain/match/dto/event/MatchStartEventDto.java
@@ -6,12 +6,12 @@ import lombok.Builder;
 @Builder
 public record MatchStartEventDto(
         Long matchId,
-        LocalDateTime StartTime
+        LocalDateTime startTime
 ) {
-    public static MatchStartEventDto from(Long matchId, LocalDateTime StartTime) {
+    public static MatchStartEventDto from(Long matchId, LocalDateTime startTime) {
         return MatchStartEventDto.builder()
                 .matchId(matchId)
-                .StartTime(StartTime)
+                .startTime(startTime)
                 .build();
     }
 }

--- a/src/main/java/org/example/oddventure/domain/match/entity/Match.java
+++ b/src/main/java/org/example/oddventure/domain/match/entity/Match.java
@@ -114,4 +114,8 @@ public class Match extends BaseEntity {
         this.loser = loser;
         this.status = MatchStatus.FINISHED;
     }
+
+    public void setStatus(MatchStatus status) {
+        this.status = status;
+    }
 }

--- a/src/main/java/org/example/oddventure/domain/match/event/MatchEventConsumer.java
+++ b/src/main/java/org/example/oddventure/domain/match/event/MatchEventConsumer.java
@@ -1,0 +1,23 @@
+package org.example.oddventure.domain.match.event;
+
+import lombok.RequiredArgsConstructor;
+import org.example.oddventure.common.config.RabbitMQConfig;
+import org.example.oddventure.domain.match.dto.event.MatchStartEventDto;
+import org.example.oddventure.domain.match.enums.MatchStatus;
+import org.example.oddventure.domain.match.service.MatchService;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MatchEventConsumer {
+
+    private final MatchService matchService;
+
+    @Transactional
+    @RabbitListener(queues = RabbitMQConfig.REAL_QUEUE)
+    public void consumeMatchStartEvent(MatchStartEventDto dto) {
+        matchService.updateStatus(dto.matchId(), MatchStatus.ONGOING);
+    }
+}

--- a/src/main/java/org/example/oddventure/domain/match/event/MatchEventProducer.java
+++ b/src/main/java/org/example/oddventure/domain/match/event/MatchEventProducer.java
@@ -15,7 +15,7 @@ public class MatchEventProducer {
     private final RabbitTemplate rabbitTemplate;
 
     public void produceMatchStartEvent(MatchStartEventDto dto) {
-        long rawDelay = Duration.between(LocalDateTime.now(), dto.StartTime()).toMillis();
+        long rawDelay = Duration.between(LocalDateTime.now(), dto.startTime()).toMillis();
         long delayMillis = Math.max(0, rawDelay); // 음수 방지 및 람다 적용을 위한 재할당
 
         rabbitTemplate.convertAndSend(

--- a/src/main/java/org/example/oddventure/domain/match/event/MatchEventProducer.java
+++ b/src/main/java/org/example/oddventure/domain/match/event/MatchEventProducer.java
@@ -1,0 +1,31 @@
+package org.example.oddventure.domain.match.event;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.example.oddventure.common.config.RabbitMQConfig;
+import org.example.oddventure.domain.match.dto.event.MatchStartEventDto;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MatchEventProducer {
+
+    private final RabbitTemplate rabbitTemplate;
+
+    public void produceMatchStartEvent(MatchStartEventDto dto) {
+        long rawDelay = Duration.between(LocalDateTime.now(), dto.StartTime()).toMillis();
+        long delayMillis = Math.max(0, rawDelay); // 음수 방지 및 람다 적용을 위한 재할당
+
+        rabbitTemplate.convertAndSend(
+                RabbitMQConfig.DELAY_EXCHANGE,
+                RabbitMQConfig.DELAY_ROUTING_KEY,
+                dto,
+                message -> {
+                    message.getMessageProperties().setExpiration(String.valueOf(delayMillis));
+                    return message;
+                }
+        );
+    }
+}

--- a/src/main/java/org/example/oddventure/domain/match/service/MatchService.java
+++ b/src/main/java/org/example/oddventure/domain/match/service/MatchService.java
@@ -5,16 +5,16 @@ import static org.springframework.transaction.annotation.Propagation.REQUIRES_NE
 import lombok.RequiredArgsConstructor;
 import org.example.oddventure.domain.admin.dto.request.MatchUpdateRequest;
 import org.example.oddventure.domain.admin.dto.response.MatchUpdateAdminResponse;
-import org.example.oddventure.domain.admin.exception.AdminErrorCode;
-import org.example.oddventure.domain.admin.exception.AdminException;
 import org.example.oddventure.domain.grid.dto.MatchScheduleDto;
 import org.example.oddventure.domain.hotKeywords.service.HotKeywordsService;
 import org.example.oddventure.domain.match.dto.MatchCreateDto;
+import org.example.oddventure.domain.match.dto.event.MatchStartEventDto;
 import org.example.oddventure.domain.match.dto.projection.MatchProjection;
 import org.example.oddventure.domain.match.dto.request.MatchSearchCondition;
 import org.example.oddventure.domain.match.dto.response.MatchResponse;
 import org.example.oddventure.domain.match.entity.Match;
 import org.example.oddventure.domain.match.enums.MatchStatus;
+import org.example.oddventure.domain.match.event.MatchEventProducer;
 import org.example.oddventure.domain.match.exception.MatchErrorCode;
 import org.example.oddventure.domain.match.exception.MatchException;
 import org.example.oddventure.domain.match.repository.MatchRepository;
@@ -29,6 +29,7 @@ public class MatchService {
 
     private final MatchRepository matchRepository;
     private final HotKeywordsService hotKeywordsService;
+    private final MatchEventProducer matchEventProducer;
 
     // 매치 생성 (매치별로 독립적인 트랜잭션 보유)
     @Transactional(propagation = REQUIRES_NEW)
@@ -49,6 +50,7 @@ public class MatchService {
                 .build();
 
         matchRepository.save(match);
+        matchEventProducer.produceMatchStartEvent(MatchStartEventDto.from(match.getId(), match.getStartTime()));
 
         return MatchCreateDto.builder().fetchId(dto.fetchId()).build();
     }
@@ -56,16 +58,9 @@ public class MatchService {
     // 매치 정보 수정
     @Transactional
     public MatchUpdateAdminResponse updateMatch(Long matchId, MatchUpdateRequest request) {
-        Match match = matchRepository.findById(matchId)
-                .orElseThrow(() -> new AdminException(AdminErrorCode.MATCH_NOT_FOUND));
+        Match match = findMatchById(matchId);
 
-        match.update(
-                request.matchName(),
-                request.teamA(),
-                request.teamB(),
-                request.startTime(),
-                request.status()
-        );
+        match.update(request.matchName(), request.teamA(), request.teamB(), request.startTime(), request.status());
 
         return MatchUpdateAdminResponse.from(match);
     }
@@ -83,8 +78,7 @@ public class MatchService {
             throw new MatchException(MatchErrorCode.MATCH_NOT_FOUND);
         }
 
-        Match match = matchRepository.findById(matchId)
-                .orElseThrow(() -> new MatchException(MatchErrorCode.MATCH_NOT_FOUND));
+        Match match = findMatchById(matchId);
 
         return MatchResponse.from(match);
     }
@@ -109,5 +103,16 @@ public class MatchService {
 
         match.finishMatch(winner, looser);
 
+    }
+
+    @Transactional
+    public void updateStatus(Long matchId, MatchStatus status) {
+        Match match = findMatchById(matchId);
+        match.setStatus(status);
+    }
+
+    private Match findMatchById(Long matchId) {
+        return matchRepository.findById(matchId)
+                .orElseThrow(() -> new MatchException(MatchErrorCode.MATCH_NOT_FOUND));
     }
 }

--- a/src/test/java/org/example/oddventure/domain/match/unit/MatchServiceTest.java
+++ b/src/test/java/org/example/oddventure/domain/match/unit/MatchServiceTest.java
@@ -17,11 +17,13 @@ import org.example.oddventure.domain.admin.dto.response.MatchUpdateAdminResponse
 import org.example.oddventure.domain.grid.dto.MatchScheduleDto;
 import org.example.oddventure.domain.hotKeywords.service.HotKeywordsService;
 import org.example.oddventure.domain.match.dto.MatchCreateDto;
+import org.example.oddventure.domain.match.dto.event.MatchStartEventDto;
 import org.example.oddventure.domain.match.dto.projection.MatchProjection;
 import org.example.oddventure.domain.match.dto.request.MatchSearchCondition;
 import org.example.oddventure.domain.match.dto.response.MatchResponse;
 import org.example.oddventure.domain.match.entity.Match;
 import org.example.oddventure.domain.match.enums.MatchStatus;
+import org.example.oddventure.domain.match.event.MatchEventProducer;
 import org.example.oddventure.domain.match.exception.MatchErrorCode;
 import org.example.oddventure.domain.match.exception.MatchException;
 import org.example.oddventure.domain.match.repository.MatchRepository;
@@ -49,6 +51,9 @@ class MatchServiceTest {
     private MatchRepository matchRepository;
 
     @Mock
+    private MatchEventProducer matchEventProducer;
+
+    @Mock
     private HotKeywordsService hotKeywordsService;
 
     @Test
@@ -61,6 +66,8 @@ class MatchServiceTest {
         Match match = Match.builder().teamA("T1").teamB("Gen.G").startTime(startTime).build();
 
         given(matchRepository.save(any(Match.class))).willReturn(match);
+        doNothing().when(matchEventProducer)
+                .produceMatchStartEvent(MatchStartEventDto.from(match.getId(), match.getStartTime()));
 
         // when
         MatchCreateDto response = matchService.createMatch(request);


### PR DESCRIPTION
## 📝 작업 내용
<!---- 변경 사항 및 관련 이슈 예시
- 컨트롤러 API 수정
- Entity 생성자 추가
- 등등
-->

- RabbitMQ 도커 컴포즈를 설정하였습니다.
- 매치 시작 시간이 되면 status = "ON_GOING"으로 변경됩니다.
- RabbitMQ console에서 관리 가능합니다.

<!---- 스크린샷 (선택) -->

## 🔗 연관된 이슈
- #58 
<!---- Related to: #(Isuue Number) -->

<!---- 리뷰 요구사항 (선택) -->

<!---- 현재 버그 (선택) -->

## ✅ PR 유형

- [x] 새로운 기능 추가
