### PR TITLE
feat: 포인트 지급 기능 구현

### DIFF
--- a/src/main/java/org/example/oddventure/common/config/RabbitMQConfig.java
+++ b/src/main/java/org/example/oddventure/common/config/RabbitMQConfig.java
@@ -5,6 +5,7 @@ import org.springframework.amqp.core.BindingBuilder;
 import org.springframework.amqp.core.DirectExchange;
 import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.core.QueueBuilder;
+import org.springframework.amqp.core.TopicExchange;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
@@ -20,6 +21,27 @@ public class RabbitMQConfig {
     public static final String REAL_QUEUE = "match.real.queue";
     public static final String DELAY_ROUTING_KEY = "match.delay";
     public static final String REAL_ROUTING_KEY = "match.real";
+    public static final String POINT_EXCHANGE = "bet.point.exchange";
+    public static final String POINT_QUEUE = "bet.point.queue";
+    public static final String POINT_ROUTING_KEY = "bet.point.adjust";
+
+    @Bean
+    public TopicExchange pointExchange() {
+        return new TopicExchange(POINT_EXCHANGE);
+    }
+
+    @Bean
+    public Queue pointQueue() {
+        return new Queue(POINT_QUEUE, true);
+    }
+
+    @Bean
+    public Binding pointBinding() {
+        return BindingBuilder
+                .bind(pointQueue())
+                .to(pointExchange())
+                .with(POINT_ROUTING_KEY);
+    }
 
     @Bean
     public DirectExchange delayExchange() {

--- a/src/main/java/org/example/oddventure/domain/admin/dto/request/PointAdjustRequest.java
+++ b/src/main/java/org/example/oddventure/domain/admin/dto/request/PointAdjustRequest.java
@@ -4,7 +4,9 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import java.math.BigDecimal;
+import lombok.Builder;
 
+@Builder
 public record PointAdjustRequest(
 
         @NotNull(message = "조정 금액은 필수 입력 값입니다.")
@@ -14,4 +16,10 @@ public record PointAdjustRequest(
         @NotBlank(message = "포인트 조정 사유는 필수 입력 값입니다.")
         String reason
 ) {
+    public static PointAdjustRequest of(BigDecimal amount, String reason) {
+        return PointAdjustRequest.builder()
+                .amount(amount)
+                .reason(reason)
+                .build();
+    }
 }

--- a/src/main/java/org/example/oddventure/domain/bet/dto/PointEventDto.java
+++ b/src/main/java/org/example/oddventure/domain/bet/dto/PointEventDto.java
@@ -1,0 +1,17 @@
+package org.example.oddventure.domain.bet.dto;
+
+import java.math.BigDecimal;
+import lombok.Builder;
+
+@Builder
+public record PointEventDto(
+        Long userId,
+        BigDecimal betAmount
+) {
+    public static PointEventDto from(Long userId, BigDecimal betAmount) {
+        return PointEventDto.builder()
+                .userId(userId)
+                .betAmount(betAmount)
+                .build();
+    }
+}

--- a/src/main/java/org/example/oddventure/domain/bet/entity/Bet.java
+++ b/src/main/java/org/example/oddventure/domain/bet/entity/Bet.java
@@ -59,4 +59,8 @@ public class Bet extends BaseEntity {
         this.oddsAtBetting = oddsAtBetting;
         this.isWin = false;
     }
+
+    public void setWin(boolean isWin) {
+        this.isWin = isWin;
+    }
 }

--- a/src/main/java/org/example/oddventure/domain/bet/event/BetEventConsumer.java
+++ b/src/main/java/org/example/oddventure/domain/bet/event/BetEventConsumer.java
@@ -1,0 +1,22 @@
+package org.example.oddventure.domain.bet.event;
+
+import lombok.RequiredArgsConstructor;
+import org.example.oddventure.common.config.RabbitMQConfig;
+import org.example.oddventure.domain.admin.dto.request.PointAdjustRequest;
+import org.example.oddventure.domain.bet.dto.PointEventDto;
+import org.example.oddventure.domain.user.service.UserService;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BetEventConsumer {
+
+    public final UserService userService;
+
+    @RabbitListener(queues = RabbitMQConfig.POINT_QUEUE)
+    public void consumePointEvent(PointEventDto dto) {
+        PointAdjustRequest request = PointAdjustRequest.of(dto.betAmount(), "배당금 지급");
+        userService.adjustUserPoints(dto.userId(), request);
+    }
+}

--- a/src/main/java/org/example/oddventure/domain/bet/event/BetEventProducer.java
+++ b/src/main/java/org/example/oddventure/domain/bet/event/BetEventProducer.java
@@ -13,6 +13,6 @@ public class BetEventProducer {
     private final RabbitTemplate rabbitTemplate;
 
     public void producePointEvent(PointEventDto dto) {
-        rabbitTemplate.convertAndSend(RabbitMQConfig.POINT_EXCHANGE, RabbitMQConfig.DELAY_ROUTING_KEY, dto);
+        rabbitTemplate.convertAndSend(RabbitMQConfig.POINT_EXCHANGE, RabbitMQConfig.POINT_ROUTING_KEY, dto);
     }
 }

--- a/src/main/java/org/example/oddventure/domain/bet/event/BetEventProducer.java
+++ b/src/main/java/org/example/oddventure/domain/bet/event/BetEventProducer.java
@@ -1,0 +1,18 @@
+package org.example.oddventure.domain.bet.event;
+
+import lombok.RequiredArgsConstructor;
+import org.example.oddventure.common.config.RabbitMQConfig;
+import org.example.oddventure.domain.bet.dto.PointEventDto;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class BetEventProducer {
+
+    private final RabbitTemplate rabbitTemplate;
+
+    public void producePointEvent(PointEventDto dto) {
+        rabbitTemplate.convertAndSend(RabbitMQConfig.POINT_EXCHANGE, RabbitMQConfig.DELAY_ROUTING_KEY, dto);
+    }
+}

--- a/src/main/java/org/example/oddventure/domain/bet/repository/BetRepository.java
+++ b/src/main/java/org/example/oddventure/domain/bet/repository/BetRepository.java
@@ -1,5 +1,6 @@
 package org.example.oddventure.domain.bet.repository;
 
+import java.util.List;
 import java.util.Optional;
 import org.example.oddventure.domain.bet.entity.Bet;
 import org.springframework.data.domain.Page;
@@ -7,6 +8,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface BetRepository extends JpaRepository<Bet, Long> {
 
@@ -16,4 +18,7 @@ public interface BetRepository extends JpaRepository<Bet, Long> {
     @EntityGraph(attributePaths = {"match", "user"})
     @Query("select b from Bet b where b.id = :id")
     Optional<Bet> findByIdForDelete(Long id);
+
+    @Query("select b from Bet b where b.match.id = :matchId")
+    List<Bet> findByMatchId(@Param("matchId") Long matchId);
 }

--- a/src/main/java/org/example/oddventure/domain/bet/service/BetService.java
+++ b/src/main/java/org/example/oddventure/domain/bet/service/BetService.java
@@ -2,13 +2,16 @@ package org.example.oddventure.domain.bet.service;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.example.oddventure.domain.bet.dto.PointEventDto;
 import org.example.oddventure.domain.bet.dto.request.BetCreateRequest;
 import org.example.oddventure.domain.bet.dto.response.BetCreateResponse;
 import org.example.oddventure.domain.bet.dto.response.BetDeleteResponse;
 import org.example.oddventure.domain.bet.dto.response.BetResponse;
 import org.example.oddventure.domain.bet.entity.Bet;
 import org.example.oddventure.domain.bet.enums.SelectedTeam;
+import org.example.oddventure.domain.bet.event.BetEventProducer;
 import org.example.oddventure.domain.bet.exception.BetErrorCode;
 import org.example.oddventure.domain.bet.exception.BetException;
 import org.example.oddventure.domain.bet.repository.BetRepository;
@@ -36,6 +39,7 @@ public class BetService {
     private final UserRepository userRepository;
     private final MatchRepository matchRepository;
     private final RedisPublisher redisPublisher;
+    private final BetEventProducer betEventProducer;
 
     @Transactional
     public BetCreateResponse createBet(Long userId, BetCreateRequest request) {
@@ -106,6 +110,20 @@ public class BetService {
         refundTotalAmount(match, bet.getBetAmount(), bet.getSelectedTeam());
 
         return BetDeleteResponse.of(bet, user);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Bet> findByMatchId(Long matchId) {
+        return betRepository.findByMatchId(matchId);
+    }
+
+    @Transactional
+    public void settleBet(Bet bet, SelectedTeam winner) {
+        if (bet.getSelectedTeam().equals(winner) && !bet.isDeleted()) {
+            bet.setWin(true);
+            BigDecimal point = bet.getBetAmount().multiply(bet.getOddsAtBetting());
+            betEventProducer.producePointEvent(PointEventDto.from(bet.getUser().getId(), point));
+        }
     }
 
     private User findUserById(Long userId) {

--- a/src/main/java/org/example/oddventure/domain/match/scheduler/MatchScheduler.java
+++ b/src/main/java/org/example/oddventure/domain/match/scheduler/MatchScheduler.java
@@ -4,6 +4,9 @@ import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.example.oddventure.domain.bet.entity.Bet;
+import org.example.oddventure.domain.bet.enums.SelectedTeam;
+import org.example.oddventure.domain.bet.service.BetService;
 import org.example.oddventure.domain.grid.dto.MatchResultDto;
 import org.example.oddventure.domain.grid.service.GridService;
 import org.example.oddventure.domain.match.entity.Match;
@@ -21,6 +24,7 @@ public class MatchScheduler {
     private final MatchRepository matchRepository;
     private final MatchService matchService;
     private final GridService gridService;
+    private final BetService betService;
 
     @Scheduled(cron = "0 0 13 * * *", zone = "Asia/Seoul")
     public void autoFinishMatches() {
@@ -44,6 +48,19 @@ public class MatchScheduler {
                     result.winner(),
                     result.loser()
             );
+            /*
+              매치에 연관된 베팅 다 조회
+              이겼는지 업데이트
+              이긴 것들만 포인트 지급 이벤트 발행
+             */
+            SelectedTeam winnerTeam = result.winner().equals(match.getTeamA())
+                    ? SelectedTeam.Team_A
+                    : SelectedTeam.Team_B;
+
+            List<Bet> bets = betService.findByMatchId(match.getId());
+            for (Bet bet : bets) {
+                betService.settleBet(bet, winnerTeam);
+            }
         } else {
             log.info("끝나지 않은 경기입니다. matchId={}, fetchId={}", match.getId(), match.getFetchId());
         }

--- a/src/test/java/org/example/oddventure/domain/bet/unit/BetEventConsumerTest.java
+++ b/src/test/java/org/example/oddventure/domain/bet/unit/BetEventConsumerTest.java
@@ -1,0 +1,52 @@
+package org.example.oddventure.domain.bet.unit;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import org.example.oddventure.domain.admin.dto.request.PointAdjustRequest;
+import org.example.oddventure.domain.admin.dto.response.PointAdjustResponse;
+import org.example.oddventure.domain.bet.dto.PointEventDto;
+import org.example.oddventure.domain.bet.event.BetEventConsumer;
+import org.example.oddventure.domain.user.service.UserService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class BetEventConsumerTest {
+
+    @InjectMocks
+    private BetEventConsumer betEventConsumer;
+
+    @Mock
+    private UserService userService;
+
+
+    @Test
+    @DisplayName("포인트 이벤트를 소비하여 포인트를 지급에 성공한다.")
+    public void consumeBetEvent_success() {
+        //given
+        Long userId = 1L;
+        BigDecimal betAmount = BigDecimal.valueOf(1000);
+        PointEventDto dto = PointEventDto.from(userId, betAmount);
+        PointAdjustRequest request = PointAdjustRequest.of(dto.betAmount(), "배당금 지급");
+        PointAdjustResponse response = new PointAdjustResponse(userId, "test", dto.betAmount(),
+                BigDecimal.valueOf(1000));
+
+        when(userService.adjustUserPoints(anyLong(), any(PointAdjustRequest.class))).thenReturn(response);
+
+        //when
+        betEventConsumer.consumePointEvent(dto);
+
+        //then
+        verify(userService).adjustUserPoints(eq(userId), eq(request));
+    }
+
+}

--- a/src/test/java/org/example/oddventure/domain/bet/unit/BetServiceTest.java
+++ b/src/test/java/org/example/oddventure/domain/bet/unit/BetServiceTest.java
@@ -5,21 +5,23 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import org.example.oddventure.domain.bet.dto.PointEventDto;
 import org.example.oddventure.domain.bet.dto.request.BetCreateRequest;
 import org.example.oddventure.domain.bet.dto.response.BetCreateResponse;
 import org.example.oddventure.domain.bet.dto.response.BetDeleteResponse;
 import org.example.oddventure.domain.bet.dto.response.BetResponse;
 import org.example.oddventure.domain.bet.entity.Bet;
 import org.example.oddventure.domain.bet.enums.SelectedTeam;
+import org.example.oddventure.domain.bet.event.BetEventProducer;
 import org.example.oddventure.domain.bet.repository.BetRepository;
 import org.example.oddventure.domain.bet.service.BetService;
-import org.example.oddventure.domain.event.RedisPublisher;
 import org.example.oddventure.domain.match.entity.Match;
 import org.example.oddventure.domain.match.repository.MatchRepository;
 import org.example.oddventure.domain.user.entity.User;
@@ -52,7 +54,7 @@ public class BetServiceTest {
     private UserRepository userRepository;
 
     @Mock
-    private RedisPublisher redisPublisher;
+    private BetEventProducer betEventProducer;
 
     @Test
     @DisplayName("베팅을 생성 성공하면 유저 포인트가 차감되고 베팅 금액이 저장된다.")
@@ -208,5 +210,51 @@ public class BetServiceTest {
                 () -> assertThat(response.matchBetResponse().teamB()).isEqualTo("GEN.G")
         );
         verify(betRepository).findByUserId(userId, pageable);
+    }
+
+    @Test
+    @DisplayName("베팅 정산에 성공한다.")
+    void settleBet_success() {
+        //given
+        Long userId = 1L;
+        User user = User.builder()
+                .username("test")
+                .email("test1234@test.com")
+                .password("test1234!")
+                .build();
+        ReflectionTestUtils.setField(user, "id", userId);
+
+        Long matchId = 1L;
+        Match match = Match.builder()
+                .teamA("T1")
+                .teamB("GEN.G")
+                .startTime(LocalDateTime.now().plusDays(1))
+                .build();
+        ReflectionTestUtils.setField(match, "id", matchId);
+
+        Long betId = 1L;
+        BigDecimal betAmount = BigDecimal.valueOf(1000);
+        BigDecimal oddsAtBetting = BigDecimal.valueOf(2);
+
+        Bet bet = Bet.builder()
+                .user(user)
+                .match(match)
+                .selectedTeam(SelectedTeam.Team_A)
+                .betAmount(betAmount)
+                .oddsAtBetting(oddsAtBetting)
+                .build();
+        ReflectionTestUtils.setField(bet, "id", betId);
+
+        SelectedTeam winner = SelectedTeam.Team_A;
+        BigDecimal point = betAmount.multiply(oddsAtBetting);
+        PointEventDto dto = PointEventDto.from(bet.getUser().getId(), point);
+
+        doNothing().when(betEventProducer).producePointEvent(dto);
+
+        //when
+        betService.settleBet(bet, winner);
+
+        //then
+        verify(betEventProducer).producePointEvent(dto);
     }
 }

--- a/src/test/java/org/example/oddventure/domain/bet/unit/BetServiceTest.java
+++ b/src/test/java/org/example/oddventure/domain/bet/unit/BetServiceTest.java
@@ -22,6 +22,7 @@ import org.example.oddventure.domain.bet.enums.SelectedTeam;
 import org.example.oddventure.domain.bet.event.BetEventProducer;
 import org.example.oddventure.domain.bet.repository.BetRepository;
 import org.example.oddventure.domain.bet.service.BetService;
+import org.example.oddventure.domain.event.RedisPublisher;
 import org.example.oddventure.domain.match.entity.Match;
 import org.example.oddventure.domain.match.repository.MatchRepository;
 import org.example.oddventure.domain.user.entity.User;
@@ -52,6 +53,9 @@ public class BetServiceTest {
 
     @Mock
     private UserRepository userRepository;
+
+    @Mock
+    private RedisPublisher redisPublisher;
 
     @Mock
     private BetEventProducer betEventProducer;


### PR DESCRIPTION
## 📝 작업 내용
<!---- 변경 사항 및 관련 이슈 예시
- 컨트롤러 API 수정
- Entity 생성자 추가
- 등등
-->

- 매치 종료 시 포인트 정산 이벤트를 발행합니다.
- 이벤트를 소비하여 자동 포인트 정산합니다.
    - 이때 중복 소비가 되지 않도록 멱등성 보장 기능을 추가해야합니다 !!!

- 아래와 같은 이유로 이벤트 기반 아키텍쳐를 선택하였습니다.
- 매치와 포인트 지급은 강한 일관성을 가지지 않는다.
- 즉, 매치가 끝났을때 포인트 지급은 언젠가 반영되면 된다.
    
    → 일정 시간에 모두 지급하는 방법 채택
    
    → 각 맡은 기능만 잘 수행하고 이벤트를 통해 전달하는 
    
    이벤트 기반 아키텍쳐가 효율적이다.
    
    - https://www.youtube.com/watch?v=DY3sUeGu74M&t=963s
    - 3:21부터

<!---- 스크린샷 (선택) -->

## 🔗 연관된 이슈
<!---- Related to: #(Isuue Number) -->

<!---- 리뷰 요구사항 (선택) -->

<!---- 현재 버그 (선택) -->

## ✅ PR 유형

- [x] 새로운 기능 추가
