### PR TITLE
chore: ECS 롤링 배포 secret manager 참조 경로 수정

### DIFF
--- a/infra/taskdef.json
+++ b/infra/taskdef.json
@@ -45,10 +45,10 @@
         { "name": "elasticsearch.password", "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<ACCOUNT_ID>:secret:<PROFILE>/elasticsearch/credentials:elasticsearch.password::" },
         { "name": "jwt.secret.key", "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<ACCOUNT_ID>:secret:<PROFILE>/api/credentials:jwt.secret.key::" },
         { "name": "grid.api.key", "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<ACCOUNT_ID>:secret:<PROFILE>/api/credentials:grid.api.key::" },
-        { "name": "grid.central.base.url", "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<ACCOUNT_ID>:secret:<PROFILE>/api/credentials/grid.central.base.url::" },
-        { "name": "grid.live.base.url", "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<ACCOUNT_ID>:secret:<PROFILE>/api/credentials/grid.live.base.url::" },
-        { "name": "openai.api.key", "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<ACCOUNT_ID>:secret:<PROFILE>/api/credentials/openai.api.key::" },
-        { "name": "openai.base.url", "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<ACCOUNT_ID>:secret:<PROFILE>/api/credentials/openai.base.url::"}
+        { "name": "grid.central.base.url", "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<ACCOUNT_ID>:secret:<PROFILE>/api/credentials:grid.central.base.url::" },
+        { "name": "grid.live.base.url", "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<ACCOUNT_ID>:secret:<PROFILE>/api/credentials:grid.live.base.url::" },
+        { "name": "openai.api.key", "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<ACCOUNT_ID>:secret:<PROFILE>/api/credentials:openai.api.key::" },
+        { "name": "openai.base.url", "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<ACCOUNT_ID>:secret:<PROFILE>/api/credentials:openai.base.url::"}
       ]
     }
   ]


### PR DESCRIPTION
## 📝 작업 내용
- SecretManager 참조 경로 재수정

## 현재 버그 
- 경로명이 잘못 참조 되어있어 운영서버 롤백 실패

## ✅ PR 유형
- [x] 새로운 기능 추가
- [ ] 코드 리팩토링
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정 및 삭제
- [ ] 그 외
