### PR TITLE
chore: 데이터베이스 초기화를 위해 DDL 잠시 변경

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -46,7 +46,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: validate
+      ddl-auto: update
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect


### PR DESCRIPTION
## 📝 작업 내용
- dda-auto의 validate에서 update로 임시 수정

현재 버그 
- Caused by: jakarta.persistence.PersistenceException: [PersistenceUnit: default] 
Unable to build Hibernate SessionFactory; nested exception is 
org.hibernate.tool.schema.spi.SchemaManagementException: Schema-validation: missing table [bet]

데이터베이스 스키마 검증 실패

## ✅ PR 유형

- [ ] 새로운 기능 추가
- [ ] 코드 리팩토링
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정 및 삭제
- [ ] 그 외
