### PR TITLE
fix: RestHighLevelClient로 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -100,6 +100,9 @@ dependencies {
     // HTTP 클라이언트 (OpenSearch 인증용)
     implementation 'org.apache.httpcomponents:httpclient:4.5.14'
 
+    //Legacy
+    implementation 'org.elasticsearch.client:elasticsearch-rest-high-level-client:7.17.18'
+
     // redisson
     implementation 'org.redisson:redisson-spring-boot-starter:3.52.0'
 

--- a/src/main/java/org/example/oddventure/common/config/ElasticsearchConfig.java
+++ b/src/main/java/org/example/oddventure/common/config/ElasticsearchConfig.java
@@ -1,13 +1,11 @@
 package org.example.oddventure.common.config;
 
-import co.elastic.clients.elasticsearch.ElasticsearchClient;
-import co.elastic.clients.json.jackson.JacksonJsonpMapper;
-import co.elastic.clients.transport.rest_client.RestClientTransport;
 import org.apache.http.HttpHost;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestHighLevelClient;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -15,7 +13,7 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 
 /**
- * AWS OpenSearch 설정 (Elasticsearch 클라이언트 사용)
+ * AWS OpenSearch 설정 (RestHighLevelClient 사용)
  * OpenSearch는 Elasticsearch 7.x REST API와 호환됨
  */
 @Configuration
@@ -32,8 +30,8 @@ public class ElasticsearchConfig {
     private String password;
 
     @Bean
-    @Primary  // 기본 Elasticsearch 클라이언트를 OpenSearch용으로 대체
-    public ElasticsearchClient elasticsearchClient() {
+    @Primary
+    public RestHighLevelClient restHighLevelClient() {
         // URI에서 호스트와 포트 추출
         String host = elasticsearchUris
                 .replace("https://", "")
@@ -70,15 +68,7 @@ public class ElasticsearchConfig {
             );
         }
 
-        // RestClient 생성
-        RestClient restClient = restClientBuilder.build();
-
-        // ElasticsearchClient 생성 (OpenSearch와 호환)
-        RestClientTransport transport = new RestClientTransport(
-                restClient,
-                new JacksonJsonpMapper()
-        );
-
-        return new ElasticsearchClient(transport);
+        // RestHighLevelClient 생성
+        return new RestHighLevelClient(restClientBuilder);
     }
 }


### PR DESCRIPTION
## 📝 작업 내용
<!---- 변경 사항 및 관련 이슈 예시
- 컨트롤러 API 수정
- Entity 생성자 추가
- 등등
-->
- 기존 ElasticsearchClient 방식에서 RestHighLevelClient 방식으로 변경
<!---- 스크린샷 (선택) -->

## 🔗 연관된 이슈
<!---- Related to: #(Isuue Number) -->

<!---- 리뷰 요구사항 (선택) -->

현재 버그 

Content-Type header [application/vnd.elasticsearch+json; compatible-with=8] is not supported
HTTP/1.1 406 Not Acceptable

Spring Data Elasticsearch 5.5.4가 사용하는 Elasticsearch Java Client 8.18.6과 AWS OpenSearch(Elasticsearch 7.x 호환) 간의 Content-Type 불일치 문제

## ✅ PR 유형

- [ ] 새로운 기능 추가
- [ ] 코드 리팩토링
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정 및 삭제
- [ ] 그 외
