### PR TITLE
fix: X-Elastic-Product 헤더를 추가

### DIFF
--- a/src/main/java/org/example/oddventure/common/config/ElasticsearchConfig.java
+++ b/src/main/java/org/example/oddventure/common/config/ElasticsearchConfig.java
@@ -82,7 +82,8 @@ public class ElasticsearchConfig {
         // 표준 "application/json" 사용
         builder.setDefaultHeaders(new Header[]{
                 new BasicHeader("Accept", "application/json"),
-                new BasicHeader("Content-Type", "application/json")
+                new BasicHeader("Content-Type", "application/json"),
+                new BasicHeader("X-Elastic-Product", "Elasticsearch")
         });
 
         // 타임아웃 설정 (선택사항)


### PR DESCRIPTION
## 📝 작업 내용
<!---- 변경 사항 및 관련 이슈 예시
- 컨트롤러 API 수정
- Entity 생성자 추가
- 등등
-->
- X-Elastic-Product 헤더를 추가

<!---- 스크린샷 (선택) -->

## 🔗 연관된 이슈
<!---- Related to: #(Isuue Number) -->

<!---- 리뷰 요구사항 (선택) -->

현재 버그
- Missing [X-Elastic-Product] header. Please check that you are connecting to an Elasticsearch instance
- Elasticsearch Java Client 8.18.6이 OpenSearch를 Elasticsearch로 인식하지 못하는 문제
## ✅ PR 유형

- [ ] 새로운 기능 추가
- [ ] 코드 리팩토링
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정 및 삭제
- [ ] 그 외
