### PR TITLE
fix: Spring Data Elasticsearch 4.4 버전으로 다운

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ repositories {
 ext {
     set('springAiVersion', "1.0.3")
     snippetsDir = file('build/generated-snippets')
-    set('springDataElasticsearchVersion', "5.3.6")
+    set('springDataElasticsearchVersion', "4.4.7")
 }
 
 dependencies {

--- a/src/main/java/org/example/oddventure/common/config/ElasticsearchConfig.java
+++ b/src/main/java/org/example/oddventure/common/config/ElasticsearchConfig.java
@@ -9,14 +9,19 @@ import org.elasticsearch.client.RestHighLevelClient;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
+import org.springframework.data.elasticsearch.config.AbstractElasticsearchConfiguration;
 import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
 
-
+/**
+ * AWS OpenSearch 설정 (Elasticsearch 7.17 버전 사용)
+ * RestHighLevelClient 기반
+ */
 @Configuration
 @Profile("prod")
 @EnableElasticsearchRepositories(basePackages = "org.example.oddventure.domain.match.repository.elasticsearch")
-public class ElasticsearchConfig {
+public class ElasticsearchConfig extends AbstractElasticsearchConfiguration {
 
     @Value("${spring.elasticsearch.uris}")
     private String elasticsearchUris;
@@ -28,13 +33,16 @@ public class ElasticsearchConfig {
     private String password;
 
     @Bean
+    @Primary
+    @Override
     public RestHighLevelClient elasticsearchClient() {
+        // URI에서 호스트와 포트 추출
         String cleanUri = elasticsearchUris
                 .replace("https://", "")
                 .replace("http://", "");
 
         String hostname;
-        int port = 443;
+        int port = 443; // AWS OpenSearch 기본 포트
 
         if (cleanUri.contains(":")) {
             String[] parts = cleanUri.split(":");


### PR DESCRIPTION
## 📝 작업 내용
<!---- 변경 사항 및 관련 이슈 예시
- 컨트롤러 API 수정
- Entity 생성자 추가
- 등등
-->

- Spring Data Elasticsearch 4.4 버전으로 다운

<!---- 스크린샷 (선택) -->

## 🔗 연관된 이슈
<!---- Related to: #(Isuue Number) -->

<!---- 리뷰 요구사항 (선택) -->

현재 버그

- Elasticsearch Template을 찾지 못하는 오류 발생

## ✅ PR 유형

- [ ] 새로운 기능 추가
- [ ] 코드 리팩토링
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정 및 삭제
- [ ] 그 외
