### PR TITLE
refactor: AI 챗봇 구조 개선 및 Redis Pub/Sub 로컬 환경 분리 적용

### DIFF
--- a/src/main/java/org/example/oddventure/common/config/RedisConfig.java
+++ b/src/main/java/org/example/oddventure/common/config/RedisConfig.java
@@ -16,6 +16,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.CacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -114,7 +115,7 @@ public class RedisConfig {
     }
 
     // --- Redis Pub/Sub 설정 ---
-
+    @Profile("local")
     @Bean
     public RedisMessageListenerContainer redisMessageListenerContainer(
             RedisConnectionFactory connectionFactory,

--- a/src/main/java/org/example/oddventure/domain/ai/controller/ChatbotController.java
+++ b/src/main/java/org/example/oddventure/domain/ai/controller/ChatbotController.java
@@ -1,15 +1,13 @@
 package org.example.oddventure.domain.ai.controller;
 
-import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.example.oddventure.common.dto.response.ApiResponse;
 import org.example.oddventure.domain.ai.agent.AgentExecutor;
 import org.example.oddventure.domain.ai.agent.AgentRunnerService;
-import org.example.oddventure.domain.ai.pubsub.RedisPublisher;
-import org.example.oddventure.domain.ai.service.LoadTestChatbotService;
+import org.example.oddventure.domain.ai.dto.UserMessage;
 import org.example.oddventure.domain.auth.dto.AuthUser;
-import org.springframework.context.annotation.Profile;
 import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -19,38 +17,19 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/chat")
-@Profile("local")
 public class ChatbotController {
 
     private final AgentRunnerService agentRunnerService;
-    private final LoadTestChatbotService loadTestChatbotService;
-    private final RedisPublisher redisPublisher;
+    private final SimpMessagingTemplate messagingTemplate;
 
-    // 로컬 테스트용
     @PostMapping
     public ResponseEntity<ApiResponse<AgentExecutor.State>> reply(
             @AuthenticationPrincipal AuthUser user,
             @RequestBody UserMessage userMessage
     ) throws Exception {
-        // 테스트용 Redis 직접 발행
-        String channel = "chat:" + user.id() + ":input";
-        redisPublisher.publish(channel, userMessage);
-
         AgentExecutor.State reply = agentRunnerService.execute(user.id(), userMessage.message()).orElse(null);
+        messagingTemplate.convertAndSend("/topic/chat/" + user.id(), reply);
+
         return ApiResponse.success(reply, "AI 응답 테스트가 정상적으로 완료되었습니다.");
-    }
-
-    @PostMapping("/loadtest")
-    public ResponseEntity<ApiResponse<String>> loadTest(
-            @RequestBody UserMessage userMessage
-    ) {
-        String reply = loadTestChatbotService.reply(userMessage.message());
-        return ApiResponse.success(reply, "부하 테스트용 응답입니다.");
-    }
-
-    public record UserMessage(
-            @NotBlank(message = "메시지를 입력해주세요!")
-            String message
-    ) {
     }
 }

--- a/src/main/java/org/example/oddventure/domain/ai/controller/ChatbotLoadTestController.java
+++ b/src/main/java/org/example/oddventure/domain/ai/controller/ChatbotLoadTestController.java
@@ -1,0 +1,29 @@
+package org.example.oddventure.domain.ai.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.example.oddventure.common.dto.response.ApiResponse;
+import org.example.oddventure.domain.ai.dto.UserMessage;
+import org.example.oddventure.domain.ai.service.LoadTestChatbotService;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Profile("local")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/chat")
+public class ChatbotLoadTestController {
+
+    private final LoadTestChatbotService loadTestChatbotService;
+
+    @PostMapping("/loadtest")
+    public ResponseEntity<ApiResponse<String>> loadTest(
+            @RequestBody UserMessage userMessage
+    ) {
+        String reply = loadTestChatbotService.reply(userMessage.message());
+        return ApiResponse.success(reply, "부하 테스트용 응답입니다.");
+    }
+}

--- a/src/main/java/org/example/oddventure/domain/ai/dto/UserMessage.java
+++ b/src/main/java/org/example/oddventure/domain/ai/dto/UserMessage.java
@@ -1,0 +1,9 @@
+package org.example.oddventure.domain.ai.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UserMessage(
+        @NotBlank(message = "메시지를 입력해주세요!")
+        String message
+) {
+}

--- a/src/main/java/org/example/oddventure/domain/ai/pubsub/ChatMessageOutputSubscriber.java
+++ b/src/main/java/org/example/oddventure/domain/ai/pubsub/ChatMessageOutputSubscriber.java
@@ -2,11 +2,13 @@ package org.example.oddventure.domain.ai.pubsub;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
 import org.springframework.data.redis.connection.Message;
 import org.springframework.data.redis.connection.MessageListener;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 
+@Profile("local")
 @Slf4j
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/org/example/oddventure/domain/ai/pubsub/ChatMessageSubscriber.java
+++ b/src/main/java/org/example/oddventure/domain/ai/pubsub/ChatMessageSubscriber.java
@@ -3,10 +3,12 @@ package org.example.oddventure.domain.ai.pubsub;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.oddventure.domain.ai.service.ChatbotService;
+import org.springframework.context.annotation.Profile;
 import org.springframework.data.redis.connection.Message;
 import org.springframework.data.redis.connection.MessageListener;
 import org.springframework.stereotype.Service;
 
+@Profile("local")
 @Slf4j
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/org/example/oddventure/domain/ai/pubsub/RedisPublisher.java
+++ b/src/main/java/org/example/oddventure/domain/ai/pubsub/RedisPublisher.java
@@ -2,14 +2,11 @@ package org.example.oddventure.domain.ai.pubsub;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
-/**
- * Redis Pub/Sub 발행자
- * <p>
- * 서버 내부에서 발생한 이벤트를 Redis 채널로 발행
- */
+@Profile("local")
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -17,7 +14,6 @@ public class RedisPublisher {
 
     private final RedisTemplate<String, Object> redisTemplate;
 
-    // 지정한 채널로 메시지를 발행
     public void publish(String channel, Object message) {
         redisTemplate.convertAndSend(channel, message);
         log.info("[Redis 발행] channel={}, message={}", channel, message);


### PR DESCRIPTION
## 📝 작업 내용

- 챗봇 구조를 **REST 입력 → AgentRunnerService → WebSocket 출력** 단일 파이프라인으로 개선
- 기존 Pub/Sub 기반 중복 응답 문제를 해결하고 전체 로직에서 제거
- `ChatMessageSubscriber`, `ChatMessageOutputSubscriber`, `RedisPublisher`에 `@Profile("local")` 적용하여 로컬 환경에서만 활성화
- `RedisMessageListenerContainer`에 `@Profile("local")` 적용하여 운영 환경에서 빈 충돌 방지
- LoadTestController를 `/loadtest` 엔드포인트로 분리하고 local 전용으로 설정
- 운영 환경 단순화 및 테스트 환경 유연성 확보

<br>

## 🔗 연관된 이슈

- Related to: #144

<br>

## ✅ PR 유형

- [ ] 새로운 기능 추가
- [x] 코드 리팩토링
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정 및 삭제
- [ ] 그 외